### PR TITLE
docs: `dotnet kubeops version` does not work

### DIFF
--- a/docs/docs/operator/cli.mdx
+++ b/docs/docs/operator/cli.mdx
@@ -101,7 +101,7 @@ Common options:
 The `version` command shows information about your current Kubernetes cluster:
 
 ```bash
-dotnet kubeops version
+dotnet kubeops api-version
 ```
 
 This displays:


### PR DESCRIPTION
Just following along in the docs. It seems like `dotnet kubeops version` does not work in the current version.

```
❯ dotnet kubeops version    
'version' was not matched. Did you mean one of the following?
--version

Required command was not provided.
Unrecognized command or argument 'version'.
```

It seems like  `dotnet kubeops api-version` is the intended command here. 

```
❯ dotnet kubeops api-version
    Kubernetes API Version    
┌─────────────┬──────────────┐
│ Git-Version │ v1.31.5+k3s1 │
│ Major       │ 1            │
│ Minor       │ 31           │
│ Platform    │ linux/arm64  │
└─────────────┴──────────────┘
```

Running on MacOs, if it makes a difference.

❯ dotnet kubeops --version
9.11.2+946bf1d8537664fe5dbf068659a809aa94f7ce57