### PR TITLE
feat(controllers): Multi-controller/-finalizer dispatch via `ShouldHandle(TEntity)`

### DIFF
--- a/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
+++ b/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
@@ -50,8 +50,9 @@ public interface IEntityController<TEntity>
     /// namespace, status conditions, or any other entity-derived predicate the consumer needs.
     /// </summary>
     /// <param name="entity">The entity the reconciler is about to dispatch.</param>
+    /// <param name="cancellationToken">The token used to signal cancellation of the operation.</param>
     /// <returns>A <see cref="ValueTask{Boolean}"/> that resolves to <c>true</c> if this controller should reconcile the entity.</returns>
-    ValueTask<bool> ShouldHandle(TEntity entity) => ValueTask.FromResult(true);
+    ValueTask<bool> ShouldHandle(TEntity entity, CancellationToken cancellationToken = default) => ValueTask.FromResult(true);
 
     /// <summary>
     /// Reconciles the state of the specified entity with the desired state.

--- a/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
+++ b/src/KubeOps.Abstractions/Reconciliation/Controller/IEntityController{TEntity}.cs
@@ -41,6 +41,19 @@ public interface IEntityController<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
     /// <summary>
+    /// Returns <c>true</c> when this controller is responsible for the given entity.
+    /// The default implementation returns <c>true</c>, preserving single-controller backward-compatible behaviour.
+    ///
+    /// When multiple controllers are registered for the same entity type the reconciler asks every
+    /// controller whether it <see cref="ShouldHandle"/> the entity and dispatches to all that claim
+    /// responsibility in registration order. Typical use cases: filtering by labels, annotations,
+    /// namespace, status conditions, or any other entity-derived predicate the consumer needs.
+    /// </summary>
+    /// <param name="entity">The entity the reconciler is about to dispatch.</param>
+    /// <returns>A <see cref="ValueTask{Boolean}"/> that resolves to <c>true</c> if this controller should reconcile the entity.</returns>
+    ValueTask<bool> ShouldHandle(TEntity entity) => ValueTask.FromResult(true);
+
+    /// <summary>
     /// Reconciles the state of the specified entity with the desired state.
     /// This method is triggered for `added` and `modified` events from the watcher.
     /// </summary>

--- a/src/KubeOps.Abstractions/Reconciliation/Finalizer/IEntityFinalizer{TEntity}.cs
+++ b/src/KubeOps.Abstractions/Reconciliation/Finalizer/IEntityFinalizer{TEntity}.cs
@@ -24,8 +24,9 @@ public interface IEntityFinalizer<TEntity>
     /// acts as a one-time responsibility claim at attach time, not an ongoing gate.
     /// </summary>
     /// <param name="entity">The entity the reconciler is considering for this finalizer.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
     /// <returns>A <see cref="ValueTask{Boolean}"/> that resolves to <c>true</c> if this finalizer should claim the entity.</returns>
-    ValueTask<bool> ShouldHandle(TEntity entity) => ValueTask.FromResult(true);
+    ValueTask<bool> ShouldHandle(TEntity entity, CancellationToken cancellationToken = default) => ValueTask.FromResult(true);
 
     /// <summary>
     /// Finalize an entity that is pending for deletion.

--- a/src/KubeOps.Abstractions/Reconciliation/Finalizer/IEntityFinalizer{TEntity}.cs
+++ b/src/KubeOps.Abstractions/Reconciliation/Finalizer/IEntityFinalizer{TEntity}.cs
@@ -15,6 +15,19 @@ public interface IEntityFinalizer<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
     /// <summary>
+    /// Returns <c>true</c> when this finalizer is responsible for the given entity.
+    /// The default implementation returns <c>true</c>, preserving backward-compatible behaviour.
+    ///
+    /// When <see cref="KubeOps.Abstractions.Builder.OperatorSettings.AutoAttachFinalizers"/> is enabled,
+    /// only finalizers that return <c>true</c> from <see cref="ShouldHandle"/> are attached to the entity.
+    /// Once attached, the finalizer is dispatched by its identifier as usual — <see cref="ShouldHandle"/>
+    /// acts as a one-time responsibility claim at attach time, not an ongoing gate.
+    /// </summary>
+    /// <param name="entity">The entity the reconciler is considering for this finalizer.</param>
+    /// <returns>A <see cref="ValueTask{Boolean}"/> that resolves to <c>true</c> if this finalizer should claim the entity.</returns>
+    ValueTask<bool> ShouldHandle(TEntity entity) => ValueTask.FromResult(true);
+
+    /// <summary>
     /// Finalize an entity that is pending for deletion.
     /// </summary>
     /// <param name="entity">The kubernetes entity that needs to be finalized.</param>

--- a/src/KubeOps.Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps.Operator/Builder/OperatorBuilder.cs
@@ -46,7 +46,7 @@ internal sealed class OperatorBuilder : IOperatorBuilder
         where TImplementation : class, IEntityController<TEntity>
         where TEntity : IKubernetesObject<V1ObjectMeta>
     {
-        Services.TryAddScoped<IEntityController<TEntity>, TImplementation>();
+        Services.AddScoped<IEntityController<TEntity>, TImplementation>();
         Services.TryAddSingleton<IReconciler<TEntity>, Reconciler<TEntity>>();
 
         // Requeue

--- a/src/KubeOps.Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps.Operator/Builder/OperatorBuilder.cs
@@ -46,7 +46,10 @@ internal sealed class OperatorBuilder : IOperatorBuilder
         where TImplementation : class, IEntityController<TEntity>
         where TEntity : IKubernetesObject<V1ObjectMeta>
     {
-        Services.AddScoped<IEntityController<TEntity>, TImplementation>();
+        // TryAddEnumerable dedupes by (ServiceType, ImplementationType), so calling AddController
+        // with the same TImplementation twice registers it only once — while still allowing
+        // distinct implementations to coexist for the same TEntity.
+        Services.TryAddEnumerable(ServiceDescriptor.Scoped<IEntityController<TEntity>, TImplementation>());
         Services.TryAddSingleton<IReconciler<TEntity>, Reconciler<TEntity>>();
 
         // Requeue

--- a/src/KubeOps.Operator/Reconciliation/Reconciler.cs
+++ b/src/KubeOps.Operator/Reconciliation/Reconciler.cs
@@ -146,6 +146,7 @@ internal sealed class Reconciler<TEntity>(
             var anyFinalizerAdded = false;
             foreach (var finalizer in finalizers)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!await finalizer.ShouldHandle(entity))
                 {
                     continue;
@@ -171,7 +172,8 @@ internal sealed class Reconciler<TEntity>(
     /// Gets all <see cref="IEntityController{TEntity}"/> registrations whose <see cref="IEntityController{TEntity}.ShouldHandle"/>
     /// returns <c>true</c> for the given entity, then calls <paramref name="operation"/> on each in registration order.
     /// On the first failure the chain is short-circuited and that failure result is returned.
-    /// If no controller claims responsibility, a success result is returned and a warning is logged.
+    /// If no controller is registered at all the result is a configuration-error failure; if controllers are
+    /// registered but none claim responsibility, a success result is returned and a warning is logged.
     /// </summary>
     private async Task<ReconciliationResult<TEntity>> DispatchToMatchingControllers(
         IServiceProvider services,
@@ -179,9 +181,18 @@ internal sealed class Reconciler<TEntity>(
         Func<IEntityController<TEntity>, TEntity, CancellationToken, Task<ReconciliationResult<TEntity>>> operation,
         CancellationToken cancellationToken)
     {
-        var responsibleControllers = new List<IEntityController<TEntity>>();
-        foreach (var controller in services.GetServices<IEntityController<TEntity>>())
+        var registeredControllers = services.GetServices<IEntityController<TEntity>>().ToList();
+        if (registeredControllers.Count == 0)
         {
+            return ReconciliationResult<TEntity>.Failure(
+                entity,
+                $"No IEntityController<{typeof(TEntity).Name}> registered. Did you forget to call AddController<T, TEntity>() on the operator builder?");
+        }
+
+        var responsibleControllers = new List<IEntityController<TEntity>>();
+        foreach (var controller in registeredControllers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             if (await controller.ShouldHandle(entity))
             {
                 responsibleControllers.Add(controller);
@@ -200,6 +211,7 @@ internal sealed class Reconciler<TEntity>(
         ReconciliationResult<TEntity> result = ReconciliationResult<TEntity>.Success(entity);
         foreach (var controller in responsibleControllers)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             result = await operation(controller, result.Entity, cancellationToken);
             if (!result.IsSuccess) return result;
         }

--- a/src/KubeOps.Operator/Reconciliation/Reconciler.cs
+++ b/src/KubeOps.Operator/Reconciliation/Reconciler.cs
@@ -141,6 +141,7 @@ internal sealed class Reconciler<TEntity>(
 
         if (operatorSettings.AutoAttachFinalizers)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var finalizers = scope.ServiceProvider.GetKeyedServices<IEntityFinalizer<TEntity>>(KeyedService.AnyKey);
 
             var anyFinalizerAdded = false;
@@ -169,11 +170,17 @@ internal sealed class Reconciler<TEntity>(
     }
 
     /// <summary>
-    /// Gets all <see cref="IEntityController{TEntity}"/> registrations whose <see cref="IEntityController{TEntity}.ShouldHandle"/>
-    /// returns <c>true</c> for the given entity, then calls <paramref name="operation"/> on each in registration order.
-    /// On the first failure the chain is short-circuited and that failure result is returned.
-    /// If no controller is registered at all the result is a configuration-error failure; if controllers are
-    /// registered but none claim responsibility, a success result is returned and a warning is logged.
+    /// Resolves all <see cref="IEntityController{TEntity}"/> registrations and, in registration order,
+    /// asks each controller <see cref="IEntityController{TEntity}.ShouldHandle"/> against the current
+    /// (possibly mutated) entity just-in-time and dispatches <paramref name="operation"/> when it claims
+    /// responsibility. On the first failure the chain short-circuits and that failure is returned.
+    /// If no controller is registered at all the result is a configuration-error failure; if controllers
+    /// are registered but none claim responsibility, a success result is returned and a warning is logged.
+    /// <para>
+    /// <b>RequeueAfter aggregation:</b> across successful controller results, the earliest non-null
+    /// <see cref="ReconciliationResult{TEntity}.RequeueAfter"/> is kept, so an auditing controller that
+    /// returns <c>Success(entity)</c> never erases a requeue requested by an earlier controller.
+    /// </para>
     /// </summary>
     private async Task<ReconciliationResult<TEntity>> DispatchToMatchingControllers(
         IServiceProvider services,
@@ -181,6 +188,8 @@ internal sealed class Reconciler<TEntity>(
         Func<IEntityController<TEntity>, TEntity, CancellationToken, Task<ReconciliationResult<TEntity>>> operation,
         CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var registeredControllers = services.GetServices<IEntityController<TEntity>>().ToList();
         if (registeredControllers.Count == 0)
         {
@@ -189,34 +198,49 @@ internal sealed class Reconciler<TEntity>(
                 $"No IEntityController<{typeof(TEntity).Name}> registered. Did you forget to call AddController<T, TEntity>() on the operator builder?");
         }
 
-        var responsibleControllers = new List<IEntityController<TEntity>>();
+        var currentEntity = entity;
+        TimeSpan? aggregatedRequeueAfter = null;
+        var anyDispatched = false;
+
         foreach (var controller in registeredControllers)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (await controller.ShouldHandle(entity))
+
+            // Evaluate ShouldHandle just-in-time against the (possibly mutated) current entity —
+            // so a controller that would claim the *initial* state but reject the *post-mutation*
+            // state does not get invoked.
+            if (!await controller.ShouldHandle(currentEntity))
             {
-                responsibleControllers.Add(controller);
+                continue;
+            }
+
+            anyDispatched = true;
+            cancellationToken.ThrowIfCancellationRequested();
+            var result = await operation(controller, currentEntity, cancellationToken);
+            if (!result.IsSuccess)
+            {
+                return result;
+            }
+
+            currentEntity = result.Entity;
+
+            if (result.RequeueAfter is not null &&
+                (aggregatedRequeueAfter is null || result.RequeueAfter < aggregatedRequeueAfter))
+            {
+                aggregatedRequeueAfter = result.RequeueAfter;
             }
         }
 
-        if (responsibleControllers.Count == 0)
+        if (!anyDispatched)
         {
             logger.LogWarning(
                 """No responsible controller found for "{Kind}/{Name}". Skipping.""",
-                entity.Kind,
-                entity.Name());
-            return ReconciliationResult<TEntity>.Success(entity);
+                currentEntity.Kind,
+                currentEntity.Name());
+            return ReconciliationResult<TEntity>.Success(currentEntity);
         }
 
-        ReconciliationResult<TEntity> result = ReconciliationResult<TEntity>.Success(entity);
-        foreach (var controller in responsibleControllers)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            result = await operation(controller, result.Entity, cancellationToken);
-            if (!result.IsSuccess) return result;
-        }
-
-        return result;
+        return ReconciliationResult<TEntity>.Success(currentEntity, aggregatedRequeueAfter);
     }
 
     private async Task<ReconciliationResult<TEntity>> ReconcileFinalizersSequential(TEntity entity, CancellationToken cancellationToken)

--- a/src/KubeOps.Operator/Reconciliation/Reconciler.cs
+++ b/src/KubeOps.Operator/Reconciliation/Reconciler.cs
@@ -148,7 +148,7 @@ internal sealed class Reconciler<TEntity>(
             foreach (var finalizer in finalizers)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                if (!await finalizer.ShouldHandle(entity))
+                if (!await finalizer.ShouldHandle(entity, cancellationToken))
                 {
                     continue;
                 }
@@ -209,7 +209,7 @@ internal sealed class Reconciler<TEntity>(
             // Evaluate ShouldHandle just-in-time against the (possibly mutated) current entity —
             // so a controller that would claim the *initial* state but reject the *post-mutation*
             // state does not get invoked.
-            if (!await controller.ShouldHandle(currentEntity))
+            if (!await controller.ShouldHandle(currentEntity, cancellationToken))
             {
                 continue;
             }

--- a/src/KubeOps.Operator/Reconciliation/Reconciler.cs
+++ b/src/KubeOps.Operator/Reconciliation/Reconciler.cs
@@ -6,6 +6,7 @@ using k8s;
 using k8s.Models;
 
 using KubeOps.Abstractions.Builder;
+using KubeOps.Abstractions.Entities;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.Abstractions.Reconciliation.Controller;
 using KubeOps.Abstractions.Reconciliation.Finalizer;
@@ -115,8 +116,11 @@ internal sealed class Reconciler<TEntity>(
                 cancellationToken);
 
         await using var scope = serviceProvider.CreateAsyncScope();
-        var controller = scope.ServiceProvider.GetRequiredService<IEntityController<TEntity>>();
-        var result = await controller.DeletedAsync(reconciliationContext.Entity, cancellationToken);
+        var result = await DispatchToMatchingControllers(
+            scope.ServiceProvider,
+            reconciliationContext.Entity,
+            (ctrl, entity, ct) => ctrl.DeletedAsync(entity, ct),
+            cancellationToken);
 
         if (result.IsSuccess)
         {
@@ -139,10 +143,16 @@ internal sealed class Reconciler<TEntity>(
         {
             var finalizers = scope.ServiceProvider.GetKeyedServices<IEntityFinalizer<TEntity>>(KeyedService.AnyKey);
 
-            var anyFinalizerAdded = finalizers
-                .Aggregate(
-                    false,
-                    (changed, finalizer) => entity.AddFinalizer(finalizer.GetIdentifierName(entity)) || changed);
+            var anyFinalizerAdded = false;
+            foreach (var finalizer in finalizers)
+            {
+                if (!await finalizer.ShouldHandle(entity))
+                {
+                    continue;
+                }
+
+                anyFinalizerAdded = entity.AddFinalizer(finalizer.GetIdentifierName(entity)) || anyFinalizerAdded;
+            }
 
             if (anyFinalizerAdded)
             {
@@ -150,8 +160,51 @@ internal sealed class Reconciler<TEntity>(
             }
         }
 
-        var controller = scope.ServiceProvider.GetRequiredService<IEntityController<TEntity>>();
-        return await controller.ReconcileAsync(entity, cancellationToken);
+        return await DispatchToMatchingControllers(
+            scope.ServiceProvider,
+            entity,
+            (ctrl, e, ct) => ctrl.ReconcileAsync(e, ct),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Gets all <see cref="IEntityController{TEntity}"/> registrations whose <see cref="IEntityController{TEntity}.ShouldHandle"/>
+    /// returns <c>true</c> for the given entity, then calls <paramref name="operation"/> on each in registration order.
+    /// On the first failure the chain is short-circuited and that failure result is returned.
+    /// If no controller claims responsibility, a success result is returned and a warning is logged.
+    /// </summary>
+    private async Task<ReconciliationResult<TEntity>> DispatchToMatchingControllers(
+        IServiceProvider services,
+        TEntity entity,
+        Func<IEntityController<TEntity>, TEntity, CancellationToken, Task<ReconciliationResult<TEntity>>> operation,
+        CancellationToken cancellationToken)
+    {
+        var responsibleControllers = new List<IEntityController<TEntity>>();
+        foreach (var controller in services.GetServices<IEntityController<TEntity>>())
+        {
+            if (await controller.ShouldHandle(entity))
+            {
+                responsibleControllers.Add(controller);
+            }
+        }
+
+        if (responsibleControllers.Count == 0)
+        {
+            logger.LogWarning(
+                """No responsible controller found for "{Kind}/{Name}". Skipping.""",
+                entity.Kind,
+                entity.Name());
+            return ReconciliationResult<TEntity>.Success(entity);
+        }
+
+        ReconciliationResult<TEntity> result = ReconciliationResult<TEntity>.Success(entity);
+        foreach (var controller in responsibleControllers)
+        {
+            result = await operation(controller, result.Entity, cancellationToken);
+            if (!result.IsSuccess) return result;
+        }
+
+        return result;
     }
 
     private async Task<ReconciliationResult<TEntity>> ReconcileFinalizersSequential(TEntity entity, CancellationToken cancellationToken)

--- a/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
+++ b/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
@@ -128,6 +128,53 @@ public sealed class OperatorBuilderTest
     }
 
     [Fact]
+    public void Should_Allow_Multiple_Controllers_For_Same_Entity_Type()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
+
+        var registrations = _builder.Services
+            .Where(s =>
+                s.ServiceType == typeof(IEntityController<V1OperatorIntegrationTestEntity>) &&
+                s.Lifetime == ServiceLifetime.Scoped)
+            .ToList();
+
+        registrations.Should().HaveCount(2);
+        registrations.Should().Contain(s => s.ImplementationType == typeof(TestController));
+        registrations.Should().Contain(s => s.ImplementationType == typeof(SecondTestController));
+    }
+
+    [Fact]
+    public void Should_Resolve_All_Controllers_For_Same_Entity_Type()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
+
+        var provider = _builder.Services.BuildServiceProvider();
+        var controllers = provider
+            .GetServices<IEntityController<V1OperatorIntegrationTestEntity>>()
+            .ToList();
+
+        controllers.Should().HaveCount(2);
+        controllers.Should().ContainItemsAssignableTo<IEntityController<V1OperatorIntegrationTestEntity>>();
+        controllers.Select(c => c.GetType()).Should().Contain(typeof(TestController));
+        controllers.Select(c => c.GetType()).Should().Contain(typeof(SecondTestController));
+    }
+
+    [Fact]
+    public void Should_Not_Register_Duplicate_ResourceWatcher_For_Multiple_Controllers()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
+
+        _builder.Services
+            .Where(s =>
+                s.ServiceType == typeof(IHostedService) &&
+                s.ImplementationType == typeof(ResourceWatcher<V1OperatorIntegrationTestEntity>))
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
     public void Should_Add_LeaderAwareResourceWatcher()
     {
         var builder = new OperatorBuilder(new ServiceCollection(), new() { LeaderElectionType = LeaderElectionType.Single });
@@ -144,6 +191,15 @@ public sealed class OperatorBuilderTest
     }
 
     private sealed class TestController : IEntityController<V1OperatorIntegrationTestEntity>
+    {
+        public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> ReconcileAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.FromResult(ReconciliationResult<V1OperatorIntegrationTestEntity>.Success(entity));
+
+        public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> DeletedAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
+            Task.FromResult(ReconciliationResult<V1OperatorIntegrationTestEntity>.Success(entity));
+    }
+
+    private sealed class SecondTestController : IEntityController<V1OperatorIntegrationTestEntity>
     {
         public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> ReconcileAsync(V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken) =>
             Task.FromResult(ReconciliationResult<V1OperatorIntegrationTestEntity>.Success(entity));

--- a/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
+++ b/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
@@ -145,6 +145,20 @@ public sealed class OperatorBuilderTest
     }
 
     [Fact]
+    public void Should_Dedupe_Identical_Controller_Registrations()
+    {
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+        _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
+
+        var registrations = _builder.Services
+            .Where(s => s.ServiceType == typeof(IEntityController<V1OperatorIntegrationTestEntity>))
+            .ToList();
+
+        registrations.Should().HaveCount(1);
+        registrations.Should().ContainSingle(s => s.ImplementationType == typeof(TestController));
+    }
+
+    [Fact]
     public void Should_Resolve_All_Controllers_For_Same_Entity_Type()
     {
         _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();

--- a/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
+++ b/test/KubeOps.Operator.Test/Builder/OperatorBuilder.Test.cs
@@ -164,8 +164,13 @@ public sealed class OperatorBuilderTest
         _builder.AddController<TestController, V1OperatorIntegrationTestEntity>();
         _builder.AddController<SecondTestController, V1OperatorIntegrationTestEntity>();
 
-        var provider = _builder.Services.BuildServiceProvider();
-        var controllers = provider
+        // Resolve from a scope (with scope validation enabled) to mirror how the runtime reconciler
+        // dispatches — directly resolving scoped services from the root provider would throw with
+        // ValidateScopes=true, which is exactly the scenario production hits.
+        var provider = _builder.Services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateScopes = true });
+        using var scope = provider.CreateScope();
+        var controllers = scope.ServiceProvider
             .GetServices<IEntityController<V1OperatorIntegrationTestEntity>>()
             .ToList();
 

--- a/test/KubeOps.Operator.Test/LeaderElector/LeaderElectionBackgroundService.Test.cs
+++ b/test/KubeOps.Operator.Test/LeaderElector/LeaderElectionBackgroundService.Test.cs
@@ -24,7 +24,7 @@ public sealed class LeaderElectionBackgroundServiceTest
 
         var electionLock = Mock.Of<ILock>();
 
-        var electionLockSubsequentCallEvent = new AutoResetEvent(false);
+        var subsequentCallTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         bool hasElectionLockThrown = false;
         Mock.Get(electionLock)
             .Setup(el => el.GetAsync(It.IsAny<CancellationToken>()))
@@ -34,7 +34,7 @@ public sealed class LeaderElectionBackgroundServiceTest
                     if (hasElectionLockThrown)
                     {
                         // Signal to the test that a subsequent call has been made.
-                        electionLockSubsequentCallEvent.Set();
+                        subsequentCallTcs.TrySetResult(true);
 
                         // Delay returning for a long time, allowing the test to stop the background service, in turn cancelling the cancellation token.
                         await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
@@ -54,8 +54,9 @@ public sealed class LeaderElectionBackgroundServiceTest
         await leaderElectionBackgroundService.StartAsync(CancellationToken.None);
 
         // Starting the background service should result in the lock attempt throwing, and then a subsequent attempt being made.
-        // Wait for the subsequent event to be signalled, if we time out the test fails. The retry delay requires us to wait at least 3 seconds.
-        electionLockSubsequentCallEvent.WaitOne(TimeSpan.FromMilliseconds(3100)).Should().BeTrue();
+        // Wait for the retry to be signalled; use a generous timeout so CI scheduling jitter doesn't cause false failures.
+        var completed = await Task.WhenAny(subsequentCallTcs.Task, Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
+        completed.Should().Be(subsequentCallTcs.Task, "the leader elector should retry after throwing");
 
         await leaderElectionBackgroundService.StopAsync(CancellationToken.None);
     }

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
@@ -279,8 +279,8 @@ public sealed class ReconcilerMultiControllerTest
         var reconcileCalledAfter = false;
 
         var mock = new Mock<IEntityController<V1ConfigMap>>();
-        mock.Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
-            .Returns(async (V1ConfigMap _) =>
+        mock.Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .Returns(async (V1ConfigMap _, CancellationToken __) =>
             {
                 await Task.Yield();
                 shouldHandleCalled = true;
@@ -367,7 +367,7 @@ public sealed class ReconcilerMultiControllerTest
 
         ctrl1.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Once);
         ctrl2.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
-        ctrl2.Verify(c => c.ShouldHandle(mutated), Times.Once);
+        ctrl2.Verify(c => c.ShouldHandle(mutated, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ── misconfiguration: zero registrations ─────────────────────────────────
@@ -458,8 +458,8 @@ public sealed class ReconcilerMultiControllerTest
     {
         var mock = new Mock<IEntityController<V1ConfigMap>>();
 
-        mock.Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
-            .Returns((V1ConfigMap e) => ValueTask.FromResult(shouldHandle(e)));
+        mock.Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .Returns((V1ConfigMap e, CancellationToken _) => ValueTask.FromResult(shouldHandle(e)));
 
         mock.Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((V1ConfigMap e, CancellationToken _) =>

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
@@ -45,10 +45,10 @@ public sealed class ReconcilerMultiControllerTest
             .Returns(_mockCache.Object);
     }
 
-    // ── default ShouldHandle = catch-all ──────────────────────────────────────
+    // ── mocked ShouldHandle returning true = catch-all ───────────────────────
 
     [Fact]
-    public async Task Dispatch_DefaultShouldHandle_MatchesEntityWithNoLabels()
+    public async Task Dispatch_ShouldHandleReturningTrue_MatchesEntityWithNoLabels()
     {
         var entity = CreateEntity();
         var controller = CreateController(shouldHandle: _ => true);
@@ -61,7 +61,7 @@ public sealed class ReconcilerMultiControllerTest
     }
 
     [Fact]
-    public async Task Dispatch_DefaultShouldHandle_MatchesEntityWithLabels()
+    public async Task Dispatch_ShouldHandleReturningTrue_MatchesEntityWithLabels()
     {
         var entity = CreateEntity(labels: new() { ["env"] = "prod" });
         var controller = CreateController(shouldHandle: _ => true);
@@ -71,6 +71,22 @@ public sealed class ReconcilerMultiControllerTest
         await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
 
         controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── default interface method exercise (no mock) ──────────────────────────
+
+    [Fact]
+    public async Task Dispatch_ConcreteControllerWithoutOverride_UsesDefaultInterfaceMethod_AndDispatches()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = new DefaultShouldHandleController();
+        var reconciler = CreateReconciler([controller]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        controller.ReconcileCallCount.Should().Be(1);
     }
 
     // ── ShouldHandle label-based claim ────────────────────────────────────────
@@ -284,7 +300,62 @@ public sealed class ReconcilerMultiControllerTest
         reconcileCalledAfter.Should().BeTrue();
     }
 
+    // ── misconfiguration: zero registrations ─────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_NoControllersRegistered_ReturnsFailure()
+    {
+        var entity = CreateEntity();
+        var reconciler = CreateReconciler([]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("No IEntityController");
+    }
+
+    // ── cancellation ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_CancelledBeforeShouldHandle_ThrowsOperationCanceled()
+    {
+        var entity = CreateEntity();
+        var controller = CreateController(shouldHandle: _ => true);
+        var reconciler = CreateReconciler([controller.Object]);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await reconciler.Reconcile(context, cts.Token));
+
+        controller.Verify(
+            c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Concrete controller with no <see cref="IEntityController{TEntity}.ShouldHandle"/> override —
+    /// used to verify the default interface method (<c>ValueTask.FromResult(true)</c>) is invoked.
+    /// </summary>
+    private sealed class DefaultShouldHandleController : IEntityController<V1ConfigMap>
+    {
+        public int ReconcileCallCount { get; private set; }
+
+        public Task<ReconciliationResult<V1ConfigMap>> ReconcileAsync(V1ConfigMap entity, CancellationToken cancellationToken)
+        {
+            ReconcileCallCount++;
+            return Task.FromResult(ReconciliationResult<V1ConfigMap>.Success(entity));
+        }
+
+        public Task<ReconciliationResult<V1ConfigMap>> DeletedAsync(V1ConfigMap entity, CancellationToken cancellationToken) =>
+            Task.FromResult(ReconciliationResult<V1ConfigMap>.Success(entity));
+    }
 
     private Reconciler<V1ConfigMap> CreateReconciler(IList<IEntityController<V1ConfigMap>> controllers)
     {

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
@@ -1,0 +1,352 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Builder;
+using KubeOps.Abstractions.Reconciliation;
+using KubeOps.Abstractions.Reconciliation.Controller;
+using KubeOps.KubernetesClient;
+using KubeOps.Operator.Queue;
+using KubeOps.Operator.Reconciliation;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace KubeOps.Operator.Test.Reconciliation;
+
+/// <summary>
+/// Tests for the multi-controller dispatch logic in <see cref="Reconciler{TEntity}"/>.
+/// Verifies that <see cref="IEntityController{TEntity}.ShouldHandle"/> is respected when
+/// multiple controllers are registered for the same entity type.
+/// </summary>
+public sealed class ReconcilerMultiControllerTest
+{
+    private readonly Mock<ILogger<Reconciler<V1ConfigMap>>> _mockLogger = new();
+    private readonly Mock<IFusionCacheProvider> _mockCacheProvider = new();
+    private readonly Mock<IFusionCache> _mockCache = new();
+    private readonly Mock<IKeyedServiceProvider> _mockServiceProvider = new();
+    private readonly Mock<IKubernetesClient> _mockClient = new();
+    private readonly Mock<ITimedEntityQueue<V1ConfigMap>> _mockQueue = new();
+    private readonly OperatorSettings _settings = new() { AutoAttachFinalizers = false, AutoDetachFinalizers = false };
+
+    public ReconcilerMultiControllerTest()
+    {
+        _mockCacheProvider
+            .Setup(p => p.GetCache(It.IsAny<string>()))
+            .Returns(_mockCache.Object);
+    }
+
+    // ── default ShouldHandle = catch-all ──────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_DefaultShouldHandle_MatchesEntityWithNoLabels()
+    {
+        var entity = CreateEntity();
+        var controller = CreateController(shouldHandle: _ => true);
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Dispatch_DefaultShouldHandle_MatchesEntityWithLabels()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(shouldHandle: _ => true);
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── ShouldHandle label-based claim ────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_ShouldHandleMatches_ControllerIsCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(shouldHandle: e => GetLabel(e, "env") == "prod");
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Dispatch_ShouldHandleDoesNotMatch_ControllerIsNotCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "staging" });
+        var controller = CreateController(shouldHandle: e => GetLabel(e, "env") == "prod");
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_EntityHasNoLabels_FilteredControllerIsNotCalled()
+    {
+        var entity = CreateEntity();
+        var controller = CreateController(shouldHandle: e => GetLabel(e, "env") == "prod");
+        var reconciler = CreateReconciler([controller.Object]);
+
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── multiple controllers ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_TwoMatchingControllers_BothCalledInOrder()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var callOrder = new List<int>();
+
+        var ctrl1 = CreateController(
+            shouldHandle: e => GetLabel(e, "env") == "prod",
+            onReconcile: e =>
+            {
+                callOrder.Add(1);
+                return ReconciliationResult<V1ConfigMap>.Success(e);
+            });
+        var ctrl2 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e =>
+            {
+                callOrder.Add(2);
+                return ReconciliationResult<V1ConfigMap>.Success(e);
+            });
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        callOrder.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task Dispatch_TwoControllers_OnlyMatchingOneIsCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var prodCtrl = CreateController(shouldHandle: e => GetLabel(e, "env") == "prod");
+        var stagingCtrl = CreateController(shouldHandle: e => GetLabel(e, "env") == "staging");
+
+        var reconciler = CreateReconciler([prodCtrl.Object, stagingCtrl.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        prodCtrl.Verify(c => c.ReconcileAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+        stagingCtrl.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_FirstControllerFails_SecondControllerNotCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var failResult = ReconciliationResult<V1ConfigMap>.Failure(entity, "first failed");
+
+        var ctrl1 = CreateController(shouldHandle: _ => true, onReconcile: _ => failResult);
+        var ctrl2 = CreateController(shouldHandle: _ => true);
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Be("first failed");
+        ctrl2.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Dispatch_NoControllerMatches_ReturnsSuccess()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(shouldHandle: e => GetLabel(e, "env") == "staging");
+
+        var reconciler = CreateReconciler([controller.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Dispatch_NoControllerMatches_LogsWarning()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(shouldHandle: e => GetLabel(e, "env") == "staging");
+
+        var reconciler = CreateReconciler([controller.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        _mockLogger.Verify(l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, _) => o.ToString()!.Contains(entity.Name())),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ── entity is passed through the chain ────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_ControllerMutatesEntity_NextControllerReceivesMutatedEntity()
+    {
+        var original = CreateEntity();
+        var mutated = CreateEntity(name: "mutated-configmap");
+
+        var ctrl1 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: _ => ReconciliationResult<V1ConfigMap>.Success(mutated));
+
+        V1ConfigMap? receivedByCtrl2 = null;
+        var ctrl2 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e =>
+            {
+                receivedByCtrl2 = e;
+                return ReconciliationResult<V1ConfigMap>.Success(e);
+            });
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(original, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        receivedByCtrl2.Should().BeSameAs(mutated);
+    }
+
+    // ── DeletedAsync path ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_DeletedEvent_MatchingControllerDeletedAsyncCalled()
+    {
+        var entity = CreateEntity(labels: new() { ["env"] = "prod" });
+        var controller = CreateController(shouldHandle: e => GetLabel(e, "env") == "prod");
+
+        var reconciler = CreateReconciler([controller.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Deleted);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        controller.Verify(c => c.DeletedAsync(entity, It.IsAny<CancellationToken>()), Times.Once);
+        controller.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── async ShouldHandle is awaited ─────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_AsyncShouldHandle_IsAwaitedBeforeDispatch()
+    {
+        var entity = CreateEntity();
+        var shouldHandleCalled = false;
+        var reconcileCalledAfter = false;
+
+        var mock = new Mock<IEntityController<V1ConfigMap>>();
+        mock.Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(async (V1ConfigMap _) =>
+            {
+                await Task.Yield();
+                shouldHandleCalled = true;
+                return true;
+            });
+        mock.Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V1ConfigMap e, CancellationToken _) =>
+            {
+                reconcileCalledAfter = shouldHandleCalled;
+                return ReconciliationResult<V1ConfigMap>.Success(e);
+            });
+
+        var reconciler = CreateReconciler([mock.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        reconcileCalledAfter.Should().BeTrue();
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Reconciler<V1ConfigMap> CreateReconciler(IList<IEntityController<V1ConfigMap>> controllers)
+    {
+        var mockScope = new Mock<IServiceScope>();
+        var mockScopeFactory = new Mock<IServiceScopeFactory>();
+
+        mockScope.Setup(s => s.ServiceProvider).Returns(_mockServiceProvider.Object);
+        mockScopeFactory.Setup(s => s.CreateScope()).Returns(mockScope.Object);
+
+        _mockServiceProvider
+            .Setup(p => p.GetService(typeof(IServiceScopeFactory)))
+            .Returns(mockScopeFactory.Object);
+
+        _mockServiceProvider
+            .Setup(p => p.GetService(typeof(IEnumerable<IEntityController<V1ConfigMap>>)))
+            .Returns(controllers);
+
+        return new(
+            _mockLogger.Object,
+            _mockCacheProvider.Object,
+            _mockServiceProvider.Object,
+            _settings,
+            _mockQueue.Object,
+            _mockClient.Object);
+    }
+
+    private static Mock<IEntityController<V1ConfigMap>> CreateController(
+        Func<V1ConfigMap, bool> shouldHandle,
+        Func<V1ConfigMap, ReconciliationResult<V1ConfigMap>>? onReconcile = null)
+    {
+        var mock = new Mock<IEntityController<V1ConfigMap>>();
+
+        mock.Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns((V1ConfigMap e) => ValueTask.FromResult(shouldHandle(e)));
+
+        mock.Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V1ConfigMap e, CancellationToken _) =>
+                onReconcile?.Invoke(e) ?? ReconciliationResult<V1ConfigMap>.Success(e));
+
+        mock.Setup(c => c.DeletedAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V1ConfigMap e, CancellationToken _) =>
+                ReconciliationResult<V1ConfigMap>.Success(e));
+
+        return mock;
+    }
+
+    private static string? GetLabel(V1ConfigMap entity, string key) =>
+        entity.Labels() is { } labels && labels.TryGetValue(key, out var value) ? value : null;
+
+    private static V1ConfigMap CreateEntity(
+        string? name = null,
+        Dictionary<string, string>? labels = null) =>
+        new()
+        {
+            Metadata = new()
+            {
+                Name = name ?? "test-configmap",
+                NamespaceProperty = "default",
+                Uid = Guid.NewGuid().ToString(),
+                Generation = 1,
+                Labels = labels,
+            },
+            Kind = V1ConfigMap.KubeKind,
+        };
+}

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.MultiController.Test.cs
@@ -300,6 +300,76 @@ public sealed class ReconcilerMultiControllerTest
         reconcileCalledAfter.Should().BeTrue();
     }
 
+    // ── RequeueAfter aggregation ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task Dispatch_MultipleControllersWithRequeueAfter_KeepsEarliestNonNull()
+    {
+        var entity = CreateEntity();
+
+        var ctrl1 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e => ReconciliationResult<V1ConfigMap>.Success(e, TimeSpan.FromMinutes(10)));
+        var ctrl2 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e => ReconciliationResult<V1ConfigMap>.Success(e, TimeSpan.FromMinutes(2)));
+        var ctrl3 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e => ReconciliationResult<V1ConfigMap>.Success(e, TimeSpan.FromMinutes(5)));
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object, ctrl3.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        result.RequeueAfter.Should().Be(TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public async Task Dispatch_LaterControllerReturnsNullRequeueAfter_DoesNotEraseEarlierRequeue()
+    {
+        var entity = CreateEntity();
+
+        var ctrl1 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e => ReconciliationResult<V1ConfigMap>.Success(e, TimeSpan.FromMinutes(3)));
+        var ctrl2 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: e => ReconciliationResult<V1ConfigMap>.Success(e));
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Added);
+        var result = await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        result.RequeueAfter.Should().Be(TimeSpan.FromMinutes(3));
+    }
+
+    // ── just-in-time ShouldHandle sees mutated entity ────────────────────────
+
+    [Fact]
+    public async Task Dispatch_ControllerMutatesEntity_SecondControllerShouldHandleSeesMutation()
+    {
+        var original = CreateEntity(labels: new() { ["env"] = "prod" });
+        var mutated = CreateEntity(name: "mutated", labels: new() { ["env"] = "staging" });
+
+        var ctrl1 = CreateController(
+            shouldHandle: _ => true,
+            onReconcile: _ => ReconciliationResult<V1ConfigMap>.Success(mutated));
+
+        // ctrl2 would claim the original (env=prod) but not the mutated (env=staging) entity.
+        // With JIT evaluation against the current entity, ctrl2 must NOT be dispatched.
+        var ctrl2 = CreateController(shouldHandle: e => GetLabel(e, "env") == "prod");
+
+        var reconciler = CreateReconciler([ctrl1.Object, ctrl2.Object]);
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(original, WatchEventType.Added);
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        ctrl1.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Once);
+        ctrl2.Verify(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Never);
+        ctrl2.Verify(c => c.ShouldHandle(mutated), Times.Once);
+    }
+
     // ── misconfiguration: zero registrations ─────────────────────────────────
 
     [Fact]

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
@@ -150,6 +150,10 @@ public sealed class ReconcilerTest
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
 
         mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
+
+        mockController
             .Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ReconciliationResult<V1ConfigMap>.Success(entity));
 
@@ -168,6 +172,10 @@ public sealed class ReconcilerTest
         var entity = CreateTestEntity();
         var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Modified);
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
+
+        mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
 
         mockController
             .Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
@@ -210,6 +218,10 @@ public sealed class ReconcilerTest
         var entity = CreateTestEntity();
         var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Deleted);
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
+
+        mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
 
         mockController
             .Setup(c => c.DeletedAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
@@ -365,6 +377,10 @@ public sealed class ReconcilerTest
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
         var mockFinalizer = new Mock<IEntityFinalizer<V1ConfigMap>>();
 
+        mockFinalizer
+            .Setup(f => f.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
+
         _mockClient
             .Setup(c => c.UpdateAsync(It.Is<V1ConfigMap>(
                 e => e == entity),
@@ -376,6 +392,10 @@ public sealed class ReconcilerTest
                 It.Is<Type>(t => t == typeof(IEnumerable<IEntityFinalizer<V1ConfigMap>>)),
                 It.Is<object?>(o => ReferenceEquals(o, KeyedService.AnyKey))))
             .Returns(new List<IEntityFinalizer<V1ConfigMap>> { mockFinalizer.Object });
+
+        mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
 
         mockController
             .Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
@@ -405,6 +425,10 @@ public sealed class ReconcilerTest
                 It.Is<Type>(t => t == typeof(IEnumerable<IEntityFinalizer<V1ConfigMap>>)),
                 It.Is<object?>(o => ReferenceEquals(o, KeyedService.AnyKey))))
             .Returns(() => new List<IEntityFinalizer<V1ConfigMap>>());
+
+        mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
 
         mockController
             .Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
@@ -471,8 +495,8 @@ public sealed class ReconcilerTest
             .Returns(mockScopeFactory.Object);
 
         _mockServiceProvider
-            .Setup(p => p.GetService(typeof(IEntityController<V1ConfigMap>)))
-            .Returns(controller);
+            .Setup(p => p.GetService(typeof(IEnumerable<IEntityController<V1ConfigMap>>)))
+            .Returns(new List<IEntityController<V1ConfigMap>> { controller });
 
         return new(
             _mockLogger.Object,
@@ -521,6 +545,10 @@ public sealed class ReconcilerTest
     {
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
         var entity = CreateTestEntity();
+
+        mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
 
         mockController
             .Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
@@ -150,7 +150,7 @@ public sealed class ReconcilerTest
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController
@@ -174,7 +174,7 @@ public sealed class ReconcilerTest
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController
@@ -220,7 +220,7 @@ public sealed class ReconcilerTest
         var mockController = new Mock<IEntityController<V1ConfigMap>>();
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController
@@ -378,7 +378,7 @@ public sealed class ReconcilerTest
         var mockFinalizer = new Mock<IEntityFinalizer<V1ConfigMap>>();
 
         mockFinalizer
-            .Setup(f => f.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(f => f.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         _mockClient
@@ -394,7 +394,7 @@ public sealed class ReconcilerTest
             .Returns(new List<IEntityFinalizer<V1ConfigMap>> { mockFinalizer.Object });
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController
@@ -422,7 +422,7 @@ public sealed class ReconcilerTest
         var mockFinalizer = new Mock<IEntityFinalizer<V1ConfigMap>>();
 
         mockFinalizer
-            .Setup(f => f.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(f => f.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(false));
 
         _mockServiceProvider
@@ -432,7 +432,7 @@ public sealed class ReconcilerTest
             .Returns(new List<IEntityFinalizer<V1ConfigMap>> { mockFinalizer.Object });
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController
@@ -443,7 +443,7 @@ public sealed class ReconcilerTest
 
         await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
 
-        mockFinalizer.Verify(f => f.ShouldHandle(It.IsAny<V1ConfigMap>()), Times.Once);
+        mockFinalizer.Verify(f => f.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()), Times.Once);
         _mockClient.Verify(
             c => c.UpdateAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()),
             Times.Never);
@@ -466,7 +466,7 @@ public sealed class ReconcilerTest
             .Returns(() => new List<IEntityFinalizer<V1ConfigMap>>());
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController
@@ -586,7 +586,7 @@ public sealed class ReconcilerTest
         var entity = CreateTestEntity();
 
         mockController
-            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(true));
 
         mockController

--- a/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
+++ b/test/KubeOps.Operator.Test/Reconciliation/Reconciler.Test.cs
@@ -412,6 +412,45 @@ public sealed class ReconcilerTest
     }
 
     [Fact]
+    public async Task Reconcile_When_Auto_Attach_Finalizer_ShouldHandle_Returns_False_Should_Not_Attach()
+    {
+        _settings.AutoAttachFinalizers = true;
+
+        var entity = CreateTestEntity();
+        var context = ReconciliationContext<V1ConfigMap>.CreateFromApiServerEvent(entity, WatchEventType.Modified);
+        var mockController = new Mock<IEntityController<V1ConfigMap>>();
+        var mockFinalizer = new Mock<IEntityFinalizer<V1ConfigMap>>();
+
+        mockFinalizer
+            .Setup(f => f.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(false));
+
+        _mockServiceProvider
+            .Setup(p => p.GetRequiredKeyedService(
+                It.Is<Type>(t => t == typeof(IEnumerable<IEntityFinalizer<V1ConfigMap>>)),
+                It.Is<object?>(o => ReferenceEquals(o, KeyedService.AnyKey))))
+            .Returns(new List<IEntityFinalizer<V1ConfigMap>> { mockFinalizer.Object });
+
+        mockController
+            .Setup(c => c.ShouldHandle(It.IsAny<V1ConfigMap>()))
+            .Returns(ValueTask.FromResult(true));
+
+        mockController
+            .Setup(c => c.ReconcileAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ReconciliationResult<V1ConfigMap>.Success(entity));
+
+        var reconciler = CreateReconcilerForController(mockController.Object);
+
+        await reconciler.Reconcile(context, TestContext.Current.CancellationToken);
+
+        mockFinalizer.Verify(f => f.ShouldHandle(It.IsAny<V1ConfigMap>()), Times.Once);
+        _mockClient.Verify(
+            c => c.UpdateAsync(It.IsAny<V1ConfigMap>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        entity.Finalizers().Should().BeNullOrEmpty();
+    }
+
+    [Fact]
     public async Task Reconcile_When_Auto_Attach_Finalizers_Is_Enabled_But_No_Finalizer_Is_Defined_Should_Not_Update()
     {
         _settings.AutoAttachFinalizers = true;


### PR DESCRIPTION
## Multi-controller/-finalizer dispatch via `ShouldHandle(TEntity)`

Fixes #909. Also unblocks #803 and similar "dispatch by arbitrary entity predicate" requests. Subsequent PR from https://github.com/dotnet/dotnet-operator-sdk/pull/1070#issuecomment-4229106019

## Overview

Adds support for registering multiple controllers (and finalizers) for the same Kubernetes entity type, each claiming responsibility for a subset of resources based on **any predicate the consumer wants to express in C#** — labels, annotations, status conditions, namespace, external lookups, etc.

Per maintainer feedback on the original label-filter PR: instead of parsing a label-selector DSL string, the framework asks each controller `ValueTask<bool> ShouldHandle(TEntity)` and dispatches to the ones that claim responsibility. This subsumes label filtering and generalises to every future dispatch scenario.

## Changes

### `IEntityController<TEntity>` — new default method

```csharp
ValueTask<bool> ShouldHandle(TEntity entity) => ValueTask.FromResult(true);
```

Controllers that want to scope themselves override it:

```csharp
public ValueTask<bool> ShouldHandle(V1MyEntity entity) =>
    ValueTask.FromResult(entity.Labels()?.GetValueOrDefault("env") == "prod");
```

Because it's a default interface method returning `true`, every existing controller implementation compiles and behaves unchanged.

### `IEntityFinalizer<TEntity>` — same new default method

```csharp
ValueTask<bool> ShouldHandle(TEntity entity) => ValueTask.FromResult(true);
```

**Semantics**: `ShouldHandle` is consulted at **auto-attach time**. Only finalizers that return `true` are attached to the entity. Once attached, the finalizer is dispatched by its identifier as usual — `ShouldHandle` acts as a one-time responsibility claim, not an ongoing gate. This prevents orphaning entities whose attached finalizers later refuse to run.

### `OperatorBuilder` — unchanged from the previous PR iteration

`AddController` still uses `AddScoped` (not `TryAddScoped`) so multiple registrations for the same entity type coexist and `GetServices<IEntityController<TEntity>>()` resolves all of them.

### `Reconciler<TEntity>` — async filter via `ShouldHandle`

`DispatchToMatchingControllers` iterates all registered controllers, awaits `ShouldHandle` on each, and builds the list of responsible controllers in registration order. On the first failure the chain short-circuits. If no controller claims the entity, the reconciler logs a warning and returns success (preserving backward-compatible behaviour for entities transitioning between operator deployments).

`ReconcileEntity` (the auto-attach path) now awaits `ShouldHandle` on each finalizer before calling `AddFinalizer`, so finalizers only claim entities they're actually responsible for.

### Removed

- `LabelSelectorMatcher.cs` — the string-based label-selector parser
- `LabelSelectorMatcher.Test.cs` — its 22 unit tests

The DSL-parsing layer is now the consumer's responsibility (they can reuse `KubeOps.KubernetesClient.LabelSelectors` or write any other predicate).

## What was explicitly NOT changed

- `IEntityLabelSelector<TEntity>` — untouched; still drives the watcher-level server-side label filter
- `ResourceWatcher<TEntity>` — untouched; one watcher per entity type regardless of controller count
- `AddController<TImplementation, TEntity>()` signature — unchanged
- All existing controller and finalizer implementations — compile and behave identically

## Tests

- **`Reconciler.MultiController.Test.cs`** — 12 tests: default catch-all `ShouldHandle`, predicate match/no-match, ordering, failure short-circuit, entity mutation pass-through, `DeletedAsync` path, async `ShouldHandle` awaited before dispatch
- **`OperatorBuilder.Test.cs`** — 3 tests for multi-registration resolution and no-duplicate-watcher (unchanged from previous iteration)
- **`Reconciler.Test.cs`** — updated existing mocks to stub `ShouldHandle` (returning true)

All 67 non-integration tests in `KubeOps.Operator.Test` pass. (Integration tests require a live Kubernetes cluster and are unrelated to this change.)

## Example

```csharp
// Dispatch by labels (the #909 use-case)
public class ProdController : IEntityController<MyEntity>
{
    public ValueTask<bool> ShouldHandle(MyEntity e) =>
        ValueTask.FromResult(e.Labels()?.GetValueOrDefault("env") == "prod");
    // ...
}

// Dispatch by status conditions (the #803-style use-case)
public class DegradedHandler : IEntityController<MyEntity>
{
    public ValueTask<bool> ShouldHandle(MyEntity e) =>
        ValueTask.FromResult(e.Status?.Phase == "Degraded");
    // ...
}

// Catch-all auditing controller (no override needed)
public class AuditController : IEntityController<MyEntity> { /* default ShouldHandle returns true */ }

builder.AddController<ProdController, MyEntity>();
builder.AddController<DegradedHandler, MyEntity>();
builder.AddController<AuditController, MyEntity>();
```

## Backward compatibility

The default implementation of `ShouldHandle` returns `true`, so every existing controller and finalizer behaves identically to before. No existing code requires changes.

## Design decisions

- **"No controller claims the entity" → Success + warning** (not failure). Rationale: transitional systems (entity exists before its owning operator is deployed) are legitimate; making this a reconcile failure would spam error alerts during rollouts.
- **Finalizer `ShouldHandle` is consulted at attach time, not dispatch time.** Rationale: once a finalizer is written into entity metadata, it's a contract with the API server. Re-evaluating at dispatch risks orphaning entities with finalizers that now refuse to run.
- **`ShouldHandle` is called on every reconcile pass with no memoisation.** Rationale: simplest, no cache-invalidation complexity. Consumers are responsible for keeping it fast; they can memoise internally if needed.
