### PR TITLE
Add --namespace parameter to kubeops generate operator

### DIFF
--- a/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
+++ b/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
@@ -40,6 +40,7 @@ internal static class OperatorGenerator
                     Options.AccessibleDockerImage,
                     Options.AccessibleDockerTag,
                     Options.NoAnsi,
+                    Options.OperatorNamespace,
                     Arguments.OperatorName,
                     Arguments.SolutionOrProjectFile,
                 };
@@ -60,6 +61,8 @@ internal static class OperatorGenerator
         var format = parseResult.GetValue(Options.OutputFormat);
         var dockerImage = parseResult.GetValue(Options.AccessibleDockerImage)!;
         var dockerImageTag = parseResult.GetValue(Options.AccessibleDockerTag)!;
+        var operatorNamespace = parseResult.GetValue(Options.OperatorNamespace);
+        var effectiveNamespace = operatorNamespace ?? $"{name}-system";
 
         var result = new ResultOutput(console, format);
         console.WriteLine("Generate operator resources.");
@@ -82,7 +85,7 @@ internal static class OperatorGenerator
         var hasWebhooks = mutators.Count > 0 || validators.Count > 0 || parser.GetConvertedEntities().Any();
 
         console.MarkupLine("[green]Generate RBAC rules.[/]");
-        new RbacGenerator(parser, format).Generate(result);
+        new RbacGenerator(parser, format, operatorNamespace ?? "system").Generate(result);
 
         console.MarkupLine("[green]Generate Dockerfile.[/]");
         new DockerfileGenerator(hasWebhooks).Generate(result);
@@ -93,7 +96,7 @@ internal static class OperatorGenerator
                 "[yellow]The operator contains webhooks of some sort, generating webhook operator specific resources.[/]");
 
             console.MarkupLine("[green]Generate CA and Server certificates.[/]");
-            new CertificateGenerator(name, $"{name}-system").Generate(result);
+            new CertificateGenerator(name, effectiveNamespace).Generate(result);
 
             console.MarkupLine("[green]Generate Deployment and Service.[/]");
             new WebhookDeploymentGenerator(format).Generate(result);
@@ -118,16 +121,19 @@ internal static class OperatorGenerator
             new CrdGenerator(parser, [], format).Generate(result);
         }
 
-        result.Add(
-            $"namespace.{format.GetFileExtension()}",
-            new V1Namespace { Metadata = new() { Name = "system" } }.Initialize());
+        if (operatorNamespace is null)
+        {
+            result.Add(
+                $"namespace.{format.GetFileExtension()}",
+                new V1Namespace { Metadata = new() { Name = "system" } }.Initialize());
+        }
 
         result.Add(
             $"kustomization.{format.GetFileExtension()}",
             new KustomizationConfig
             {
                 NamePrefix = $"{name}-",
-                Namespace = $"{name}-system",
+                Namespace = effectiveNamespace,
                 Labels = [new(new Dictionary<string, string> { { OperatorName, name }, })],
                 Resources = result.DefaultFormatFiles.ToList(),
                 Images =

--- a/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
+++ b/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
@@ -85,7 +85,7 @@ internal static class OperatorGenerator
         var hasWebhooks = mutators.Count > 0 || validators.Count > 0 || parser.GetConvertedEntities().Any();
 
         console.MarkupLine("[green]Generate RBAC rules.[/]");
-        new RbacGenerator(parser, format, operatorNamespace ?? "system").Generate(result);
+        new RbacGenerator(parser, format, effectiveNamespace).Generate(result);
 
         console.MarkupLine("[green]Generate Dockerfile.[/]");
         new DockerfileGenerator(hasWebhooks).Generate(result);

--- a/src/KubeOps.Cli/Generators/RbacGenerator.cs
+++ b/src/KubeOps.Cli/Generators/RbacGenerator.cs
@@ -16,7 +16,8 @@ namespace KubeOps.Cli.Generators;
 
 internal sealed class RbacGenerator(
     MetadataLoadContext parser,
-    OutputFormat outputFormat) : IConfigGenerator
+    OutputFormat outputFormat,
+    string subjectNamespace) : IConfigGenerator
 {
     public void Generate(ResultOutput output)
     {
@@ -49,7 +50,7 @@ internal sealed class RbacGenerator(
                 {
                     Kind = V1ServiceAccount.KubeKind,
                     Name = "default",
-                    NamespaceProperty = "system",
+                    NamespaceProperty = subjectNamespace,
                 },
             },
         }

--- a/src/KubeOps.Cli/Options.cs
+++ b/src/KubeOps.Cli/Options.cs
@@ -72,7 +72,7 @@ internal static class Options
     public static readonly Option<string?> OperatorNamespace = new("--namespace", "-n")
     {
         Description = "The Kubernetes namespace for the operator deployment. " +
-                      "If omitted, a namespace resource named '<operator name>-system' is generated." +
+                      "If omitted, a namespace resource for the operator deployment is generated using the default system namespace naming. " +
                       "If specified, the namespace is not generated and must already exist in the cluster.",
     };
 }

--- a/src/KubeOps.Cli/Options.cs
+++ b/src/KubeOps.Cli/Options.cs
@@ -68,4 +68,11 @@ internal static class Options
         Description = "Disable ANSI output.",
         DefaultValueFactory = _ => false,
     };
+
+    public static readonly Option<string?> OperatorNamespace = new("--namespace", "-n")
+    {
+        Description = "The Kubernetes namespace for the operator deployment. " +
+                      "If omitted, a namespace resource named '<operator name>-system' is generated." +
+                      "If specified, the namespace is not generated and must already exist in the cluster.",
+    };
 }


### PR DESCRIPTION
Adds the `--namespace` parameter to the `generate operator` command.
Because of how kustomize works, when the namespace is specified, the generator will skip creating the `Namespace` resource, meaning that the specified namespace must already exist in the cluster.
Closes #1108
