### PR TITLE
feat: Add `ToIdentifierString` overloads

### DIFF
--- a/src/KubeOps.Operator/Logging/KubernetesObjectExtensions.cs
+++ b/src/KubeOps.Operator/Logging/KubernetesObjectExtensions.cs
@@ -34,4 +34,50 @@ public static class KubernetesObjectExtensions
     /// </example>
     public static string ToIdentifierString(this IKubernetesObject<V1ObjectMeta> kubernetesObject)
         => $"{kubernetesObject.Kind}{(string.IsNullOrEmpty(kubernetesObject.Name()) ? string.Empty : $"/{kubernetesObject.Name()}")}{(string.IsNullOrEmpty(kubernetesObject.Uid()) ? string.Empty : $" (UID: {kubernetesObject.Uid()})")}";
+
+    /// <summary>
+    /// Builds a human-readable identifier string for the Kubernetes object reference, suitable for use in log messages.
+    /// </summary>
+    /// <param name="objectReference">The Kubernetes object reference to identify.</param>
+    /// <returns>
+    /// A string that identifies the object reference. The format varies depending on which fields are populated:
+    /// <list type="bullet">
+    /// <item><description><c>Kind/Name (UID: uid)</c> when all fields are present.</description></item>
+    /// <item><description><c>Kind (UID: uid)</c> when the name is absent.</description></item>
+    /// <item><description><c>Kind/Name</c> when the UID is absent.</description></item>
+    /// <item><description><c>Kind</c> when only the kind is present.</description></item>
+    /// </list>
+    /// </returns>
+    /// <example>
+    /// <code language="csharp">
+    /// V1ObjectReference objectReference = ...;
+    /// logger.LogInformation("Processing {Identifier}.", objectReference.ToIdentifierString());
+    /// // Output: "Processing MyKind/my-name (UID: 1a2b3c)."
+    /// </code>
+    /// </example>
+    public static string ToIdentifierString(this V1ObjectReference objectReference)
+        => $"{objectReference.Kind}{(string.IsNullOrEmpty(objectReference.Name) ? string.Empty : $"/{objectReference.Name}")}{(string.IsNullOrEmpty(objectReference.Uid) ? string.Empty : $" (UID: {objectReference.Uid})")}";
+
+    /// <summary>
+    /// Builds a human-readable identifier string for the Kubernetes owner reference, suitable for use in log messages.
+    /// </summary>
+    /// <param name="ownerReference">The Kubernetes owner reference to identify.</param>
+    /// <returns>
+    /// A string that identifies the owner reference. The format varies depending on which fields are populated:
+    /// <list type="bullet">
+    /// <item><description><c>Kind/Name (UID: uid)</c> when all fields are present.</description></item>
+    /// <item><description><c>Kind (UID: uid)</c> when the name is absent.</description></item>
+    /// <item><description><c>Kind/Name</c> when the UID is absent.</description></item>
+    /// <item><description><c>Kind</c> when only the kind is present.</description></item>
+    /// </list>
+    /// </returns>
+    /// <example>
+    /// <code language="csharp">
+    /// V1OwnerReference ownerReference = ...;
+    /// logger.LogInformation("Processing {Identifier}.", ownerReference.ToIdentifierString());
+    /// // Output: "Processing MyKind/my-name (UID: 1a2b3c)."
+    /// </code>
+    /// </example>
+    public static string ToIdentifierString(this V1OwnerReference ownerReference)
+        => $"{ownerReference.Kind}{(string.IsNullOrEmpty(ownerReference.Name) ? string.Empty : $"/{ownerReference.Name}")}{(string.IsNullOrEmpty(ownerReference.Uid) ? string.Empty : $" (UID: {ownerReference.Uid})")}";
 }

--- a/test/KubeOps.Operator.Test/Logging/KubernetesObjectExtensions.Test.cs
+++ b/test/KubeOps.Operator.Test/Logging/KubernetesObjectExtensions.Test.cs
@@ -44,6 +44,70 @@ public sealed class KubernetesObjectExtensionsTest
         obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}");
     }
 
+    [Fact]
+    public void ObjectReference_ToIdentifierString_Should_Include_Kind_Name_And_Uid_When_All_Present()
+    {
+        var obj = CreateObjectReference(name: "my-config", uid: "abc-123");
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}/my-config (UID: abc-123)");
+    }
+
+    [Fact]
+    public void ObjectReference_ToIdentifierString_Should_Omit_Name_When_Name_Is_Absent()
+    {
+        var obj = CreateObjectReference(name: null, uid: "abc-123");
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind} (UID: abc-123)");
+    }
+
+    [Fact]
+    public void ObjectReference_ToIdentifierString_Should_Omit_Uid_When_Uid_Is_Absent()
+    {
+        var obj = CreateObjectReference(name: "my-config", uid: null);
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}/my-config");
+    }
+
+    [Fact]
+    public void ObjectReference_ToIdentifierString_Should_Return_Only_Kind_When_Name_And_Uid_Are_Absent()
+    {
+        var obj = CreateObjectReference(name: null, uid: null);
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}");
+    }
+
+    [Fact]
+    public void OwnerReference_ToIdentifierString_Should_Include_Kind_Name_And_Uid_When_All_Present()
+    {
+        var obj = CreateOwnerReference(name: "my-config", uid: "abc-123");
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}/my-config (UID: abc-123)");
+    }
+
+    [Fact]
+    public void OwnerReference_ToIdentifierString_Should_Omit_Name_When_Name_Is_Absent()
+    {
+        var obj = CreateOwnerReference(name: null, uid: "abc-123");
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind} (UID: abc-123)");
+    }
+
+    [Fact]
+    public void OwnerReference_ToIdentifierString_Should_Omit_Uid_When_Uid_Is_Absent()
+    {
+        var obj = CreateOwnerReference(name: "my-config", uid: null);
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}/my-config");
+    }
+
+    [Fact]
+    public void OwnerReference_ToIdentifierString_Should_Return_Only_Kind_When_Name_And_Uid_Are_Absent()
+    {
+        var obj = CreateOwnerReference(name: null, uid: null);
+
+        obj.ToIdentifierString().Should().Be($"{V1ConfigMap.KubeKind}");
+    }
+
     private static V1ConfigMap CreateObject(string? name, string? uid)
         => new()
         {
@@ -53,5 +117,21 @@ public sealed class KubernetesObjectExtensionsTest
                 Name = name,
                 Uid = uid,
             },
+        };
+
+    private static V1ObjectReference CreateObjectReference(string? name, string? uid)
+        => new()
+        {
+            Kind = V1ConfigMap.KubeKind,
+            Name = name,
+            Uid = uid,
+        };
+
+    private static V1OwnerReference CreateOwnerReference(string? name, string? uid)
+        => new()
+        {
+            Kind = V1ConfigMap.KubeKind,
+            Name = name,
+            Uid = uid,
         };
 }


### PR DESCRIPTION
This is for convenience and consistency when the operator needs to log some object identity or reference. 