### PR TITLE
chore: update MSBuild package versions and add TFM-specific dependencies

### DIFF
--- a/KubeOps.slnx
+++ b/KubeOps.slnx
@@ -9,7 +9,6 @@
   <Folder Name="/solution/">
     <File Path=".editorconfig" />
     <File Path=".gitignore" />
-    <File Path=".releaserc.json" />
     <File Path="renovate.json" />
     <File Path="README.md" />
     <File Path="CONTRIBUTING.md" />

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,20 @@
       "semanticCommitScope": "docs"
     },
     {
+      "description": ["Keep MSBuild packages on the latest net8.0-compatible 17.11 line for net8.0 TFMs."],
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Microsoft.Build.Framework", "Microsoft.NET.StringTools"],
+      "matchCurrentValue": "/^17\\.11\\./",
+      "allowedVersions": "<17.12.0"
+    },
+    {
+      "description": ["Keep MSBuild packages on the latest net9.0-compatible 17.14 line for net9.0 TFMs."],
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Microsoft.Build.Framework", "Microsoft.NET.StringTools"],
+      "matchCurrentValue": "/^17\\.14\\./",
+      "allowedVersions": "<18.0.0"
+    },
+    {
       "matchPackageNames": ["JsonPatch.Net"],
       "allowedVersions": "<=4.0.1"
     }

--- a/src/KubeOps.Cli/KubeOps.Cli.csproj
+++ b/src/KubeOps.Cli/KubeOps.Cli.csproj
@@ -24,14 +24,27 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" />
-        <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
         <PackageReference Include="Spectre.Console" Version="0.55.2" />
         <PackageReference Include="Spectre.Console.Analyzer" Version="1.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.CommandLine" Version="2.0.8" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.StringTools" Version="17.11.48" ExcludeAssets="runtime" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.Build.Framework" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.StringTools" Version="17.14.28" ExcludeAssets="runtime" PrivateAssets="all" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Build.Framework" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.NET.StringTools" Version="18.6.3" ExcludeAssets="runtime" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Modified `KubeOps.Cli.csproj` to include TFM-specific `Microsoft.Build.Framework` and `Microsoft.NET.StringTools` dependencies.
- Updated `renovate.json` to enforce version constraints for MSBuild packages based on TFM.