### PR TITLE
fix(transpiler): use `JsonNamingPolicy.CamelCase` for consistent property naming

### DIFF
--- a/src/KubeOps.Transpiler/Crds.cs
+++ b/src/KubeOps.Transpiler/Crds.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.Reflection;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using k8s;
@@ -206,7 +207,7 @@ public static class Crds
             { } attr => attr.GetCustomAttributeCtorArg<string>(context, 0) ?? prop.Name,
         };
 
-        return $"{name[..1].ToLowerInvariant()}{name[1..]}";
+        return JsonNamingPolicy.CamelCase.ConvertName(name);
     }
 
     private static IEnumerable<V1CustomResourceColumnDefinition> MapPrinterColumns(

--- a/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
@@ -722,6 +722,21 @@ public sealed partial class CrdsMlcTest(MlcProvider provider) : TranspilerTestBa
 
     [Trait("Area", "General")]
     [Fact]
+    public void Should_Use_Kubernetes_Json_Property_Naming_For_Acronym_Prefixes()
+    {
+        var crd = _mlc.Transpile(typeof(AcronymPropertyNameEntity));
+
+        var specProperties = crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties;
+        specProperties.Should().ContainKey("ipAddress");
+        specProperties.Should().NotContainKey("iPAddress");
+
+        var itemProperties = ((V1JSONSchemaProps)specProperties["hostIPs"].Items!).Properties;
+        itemProperties.Should().ContainKey("ipAddress");
+        itemProperties.Should().NotContainKey("iPAddress");
+    }
+
+    [Trait("Area", "General")]
+    [Fact]
     public void Must_Not_Contain_Ignored_TopLevel_Properties()
     {
         var crd = _mlc.Transpile(typeof(Entity));
@@ -1538,6 +1553,19 @@ public sealed partial class CrdsMlcTest(MlcProvider provider) : TranspilerTestBa
     {
         [JsonPropertyName("otherName")]
         public string Property { get; set; } = null!;
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    public class AcronymPropertyNameEntity : CustomKubernetesEntity
+    {
+        public string IPAddress { get; set; } = null!;
+
+        public HostIPCache[] HostIPs { get; set; } = [];
+
+        public class HostIPCache
+        {
+            public string IPAddress { get; set; } = null!;
+        }
     }
 
     #endregion


### PR DESCRIPTION
- added a test for acronym handling

fixes #804 