### PR TITLE
chore(workflows): update checkout settings and semantic-release dependencies

### DIFF
--- a/.github/workflows/dotnet-pre-release.yml
+++ b/.github/workflows/dotnet-pre-release.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -39,7 +40,7 @@ jobs:
             @semantic-release/github \
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
-            conventional-changelog-conventionalcommits \
+            conventional-changelog-conventionalcommits@^9 \
             semantic-release-net
 
       - name: Semantic Release

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -38,7 +39,7 @@ jobs:
             @semantic-release/github \
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
-            conventional-changelog-conventionalcommits \
+            conventional-changelog-conventionalcommits@^9 \
             semantic-release-net
 
       - name: Semantic Release


### PR DESCRIPTION
- Set `fetch-depth` to 0 and enabled `fetch-tags` for release workflows.
- Updated `conventional-changelog-conventionalcommits` to version ^9.