### PR TITLE
feat(operator)!: add enriched entity logging scopes

### DIFF
--- a/docs/docs/operator/migration.mdx
+++ b/docs/docs/operator/migration.mdx
@@ -230,6 +230,19 @@ constructed it directly are affected.
 **Migration:** pass the concrete controller type when constructing `Reconciler<TEntity>` yourself, or
 rely on the SDK's registration.
 
+### Entity logging scopes are created through a factory
+
+`ResourceWatcher<TEntity>`, `EntityQueueBackgroundService<TEntity>` and their leader-/scope-aware
+derivations take an additional `IEntityLoggingScopeFactory<TEntity>` argument. The factory applies all
+registered enrichers while creating the scope (see
+[Logging](./observability/logging#enriching-scopes-with-custom-fields)).
+
+**Migration:** resolve `IEntityLoggingScopeFactory<TEntity>` through dependency injection. Use its
+`CreateFor(...)` methods to create an enriched scope, and pass the factory when directly constructing or
+subclassing the watcher and queue types. `EntityLoggingScope.CreateFor(...)` remains available for standalone,
+unenriched scopes. The default factory is registered automatically per entity type and is a no-op beyond the
+built-in fields when no enrichers are configured.
+
 ### New in v13 (non-breaking)
 
 - **Scoped leader election**: `LeaderElectionType.Scoped` partitions responsibility across

--- a/docs/docs/operator/observability/logging.mdx
+++ b/docs/docs/operator/observability/logging.mdx
@@ -6,40 +6,104 @@ sidebar_position: 1
 
 # Logging
 
-## Logging with `ILogger` and Scopes
+## Logging with `ILogger` and scopes
 
-This project uses Microsoft's [`ILogger`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging) interface for logging. It provides a standardized and extensible way to capture events within the application.
+KubeOps uses Microsoft's [`ILogger`](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging) abstraction.
+Application code can use the same logging pipeline by injecting a category logger such as
+`ILogger<V1DemoEntityController>`.
 
 Using _scopes_ enables hierarchical organization of log messages and allows contextual information to be attached to each entry.
 
-### ILogger Basics
+### `ILogger` basics
 
-The `ILogger` interface is part of [`Microsoft.Extensions.Logging`](https://www.nuget.org/packages/Microsoft.Extensions.Logging) and provides methods to log messages at various severity levels (e.g., `Information`, `Warning`, `Error`).
+The default application builders (`WebApplication.CreateBuilder` and `Host.CreateApplicationBuilder`) register
+logging automatically. For a manually assembled service collection, call `services.AddLogging()`.
 
-Logging can be enabled using either `WebApplication.CreateBuilder`, `Host.CreateDefaultBuilder`, or the `AddLogging` extension method on the `IServiceCollection`.
-
-You can log from your code by injecting `ILogger<MyEntityController>` (or a similar type) into your component.
-
-### Using Scopes
+### Entity scopes
 
 Scopes define a logical boundary in which all log entries are automatically enriched with contextual metadata. This is especially useful for correlating logs related to a specific request or operation.
 
-By default, two components start a new scope for each operation they perform:
+Two operator components create entity scopes:
 
-- The [ResourceWatcher](https://github.com/dotnet/dotnet-operator-sdk/blob/main/src/KubeOps.Operator/Watcher/ResourceWatcher%7BTEntity%7D.cs) opens a scope for every watch event received from the Kubernetes API server.
-- The [EntityQueueBackgroundService](https://github.com/dotnet/dotnet-operator-sdk/blob/main/src/KubeOps.Operator/Queue/EntityQueueBackgroundService%7BTEntity%7D.cs) opens a scope for every queue entry it processes before invoking the reconciler.
+- `ResourceWatcher<TEntity>` opens a scope around every watch event received from the Kubernetes API server,
+  including bookmark events.
+- `EntityQueueBackgroundService<TEntity>` opens one scope around every dequeued entry. The scope is built from the
+  entity snapshot stored in the queue and covers lock handling, entity loading, reconciliation, retry scheduling,
+  and skips. A later retry is a new queue entry and therefore receives a new scope.
 
 Both scopes carry the same fields:
 
-- `EventType`: Type of the reconciliation operation (`Added`, `Modified`, `Deleted`)
-- `ReconciliationTriggerSource`: Origin of the reconciliation request (`ApiServer` for watch events, `Operator` for internal retries and periodic requeues)
-- `Kind`: Custom Resource Definition (CRD) kind
-- `Namespace`: CRD namespace
-- `Name`: CRD name
-- `Uid`: CRD unique identifier
-- `ResourceVersion`: CRD resource version
+- `EventType`: watch/reconciliation operation (`Added`, `Modified`, `Deleted`, or `Bookmark` for watch scopes)
+- `ReconciliationTriggerSource`: `ApiServer` for watch-derived work, or `Operator` for a delayed requeue requested
+  by a reconciler. Error retries and lock-conflict requeues preserve the trigger source of the original entry
+- `Kind`: Kubernetes object kind
+- `Namespace`: Kubernetes object namespace
+- `Name`: Kubernetes object name
+- `Uid`: Kubernetes object UID
+- `ResourceVersion`: Kubernetes object resource version
 
-You can create additional scopes in your code using `logger.BeginScope(state)`, where `state` can be either a string or a custom object.
+For `Added` and `Modified` entries, the queue service still loads the current object from the API server before
+dispatching it to the reconciler. The logging scope deliberately remains based on the queued event snapshot. Its
+`ResourceVersion` and entity-derived custom fields therefore describe the event that caused the queue entry, not
+necessarily the newer object instance passed to the reconciler. Controllers that need a scope based on the current
+object can create one explicitly through `IEntityLoggingScopeFactory<TEntity>`.
+
+### Enriching scopes with custom fields
+
+The built-in fields can be extended with custom structured properties on both watch and reconcile scopes.
+Implement `IEntityLoggingScopeEnricher<TEntity>` for the entity type and register it on the operator builder:
+
+```csharp
+public sealed class DemoEnricher : IEntityLoggingScopeEnricher<V1DemoEntity>
+{
+    public void Enrich(
+        V1DemoEntity entity,
+        EntityLoggingPhase phase,
+        IDictionary<string, object> properties)
+    {
+        properties.TryAdd("Owner", entity.Spec.Owner);
+        properties.TryAdd("Phase", phase);
+    }
+}
+```
+
+```csharp
+builder.AddEntityLoggingScopeEnricher<V1DemoEntity, DemoEnricher>();
+```
+
+Inject `IEntityLoggingScopeFactory<TEntity>` when application code needs the same enriched scope:
+
+```csharp
+public sealed class DemoService(
+    ILogger<DemoService> logger,
+    IEntityLoggingScopeFactory<V1DemoEntity> scopeFactory)
+{
+    public void LogWatchEvent(WatchEventType eventType, V1DemoEntity entity)
+    {
+        using var scope = logger.BeginScope(scopeFactory.CreateFor(eventType, entity));
+        logger.LogInformation("Processing an application-defined watch event.");
+    }
+}
+```
+
+Semantics and constraints:
+
+- **Lifetime**: enrichers are registered and resolved as singletons and must be thread-safe because watch and
+  reconciliation scopes can be created concurrently.
+- **Synchronous hot path**: `Enrich` is called whenever an entity scope is built: once per watch event and once per
+  dequeued reconciliation entry. Enrichers must be synchronous, cheap, side-effect free, and only read from the
+  supplied `entity`; do not perform I/O or call the Kubernetes API.
+- **Phase**: `phase` is either `Watch` or `Reconcile`, so an enricher can contribute
+  phase-specific data.
+- **Order and add-only semantics**: enrichers run in registration order. Contributions are merged with
+  first-writer-wins semantics, so enrichers cannot change or remove the built-in identification fields or
+  properties contributed by an earlier enricher.
+- **Error isolation**: if an enricher throws, the failure is logged and skipped; the remaining enrichers
+  still run and watching/reconciliation is never interrupted.
+
+`EntityLoggingScope.CreateFor(...)` remains available for standalone scopes that only need the seven built-in
+fields. It does not resolve dependency injection and therefore does not run registered enrichers; use
+`IEntityLoggingScopeFactory<TEntity>` when enrichment is required.
 
 To include scopes in the logging output, they must be explicitly enabled either via configuration or code:
 
@@ -60,29 +124,26 @@ To include scopes in the logging output, they must be explicitly enabled either 
 }
 ```
 
-**Programmatic configuration:**
+**Programmatic console configuration:**
 
 ```csharp
-builder
-    .ConfigureLogging((hostBuilderContext, loggingBuilder) =>
-    {
-        loggingBuilder
-            .AddSimpleConsole(options => options.IncludeScopes = true);
-    });
+builder.Logging.AddSimpleConsole(options => options.IncludeScopes = true);
 ```
 
 :::tip
-To enable scopes with OpenTelemetry, configure it as follows:
+For the OpenTelemetry logging provider, enable scope capture when registering the provider:
 
-```json
-"OpenTelemetry": {
-  "IncludeScopes": true,
-  "ParseStateValues": true,
-  "IncludeFormattedMessage": true
-}
+```csharp
+builder.Logging.AddOpenTelemetry(options =>
+{
+    options.IncludeScopes = true;
+    options.ParseStateValues = true;
+    options.IncludeFormattedMessage = true;
+});
 ```
 
-The scope state must be an `IReadOnlyDictionary<string, object?>` to ensure correct serialization and inclusion in log entries.
+This registers the provider; configure an exporter separately. Projects using `KubeOps.Aspire` can instead call
+`AddKubeOpsServiceDefaults()`, which enables OpenTelemetry scope capture as part of the service defaults.
 :::
 
 :::tip

--- a/src/KubeOps.Abstractions/Builder/EntityLoggingScopeEnricherBuilderExtensions.cs
+++ b/src/KubeOps.Abstractions/Builder/EntityLoggingScopeEnricherBuilderExtensions.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Logging;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KubeOps.Abstractions.Builder;
+
+/// <summary>
+/// Registration helpers for <see cref="IEntityLoggingScopeEnricher{TEntity}"/> implementations that contribute
+/// additional structured properties to the logging scope surrounding every watch event and reconciliation.
+/// </summary>
+public static class EntityLoggingScopeEnricherBuilderExtensions
+{
+    /// <summary>
+    /// Registers a logging scope enricher applied to scopes created for <typeparamref name="TEntity"/>.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity type the enricher applies to.</typeparam>
+    /// <typeparam name="TEnricher">The enricher implementation.</typeparam>
+    /// <param name="builder">The operator builder.</param>
+    /// <returns>The same builder for chaining.</returns>
+    public static IOperatorBuilder AddEntityLoggingScopeEnricher<TEntity, TEnricher>(this IOperatorBuilder builder)
+        where TEntity : IKubernetesObject<V1ObjectMeta>
+        where TEnricher : class, IEntityLoggingScopeEnricher<TEntity>
+    {
+        builder.Services.AddSingleton<IEntityLoggingScopeEnricher<TEntity>, TEnricher>();
+        return builder;
+    }
+}

--- a/src/KubeOps.Abstractions/Logging/EntityLoggingPhase.cs
+++ b/src/KubeOps.Abstractions/Logging/EntityLoggingPhase.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace KubeOps.Abstractions.Logging;
+
+/// <summary>
+/// Identifies the pipeline stage in which an entity logging scope is being created, allowing
+/// enrichers to contribute different properties for a watch event than for a reconciliation.
+/// </summary>
+public enum EntityLoggingPhase
+{
+    /// <summary>The scope is created while ingesting a watch event from the API server.</summary>
+    Watch,
+
+    /// <summary>The scope is created while reconciling a queued entity.</summary>
+    Reconcile,
+}

--- a/src/KubeOps.Abstractions/Logging/IEntityLoggingScopeEnricher.cs
+++ b/src/KubeOps.Abstractions/Logging/IEntityLoggingScopeEnricher.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using k8s;
+using k8s.Models;
+
+namespace KubeOps.Abstractions.Logging;
+
+/// <summary>
+/// Contributes additional structured properties to logging scopes created for <typeparamref name="TEntity"/>.
+/// Enrichers can add properties, but cannot change or remove existing properties.
+/// </summary>
+/// <typeparam name="TEntity">The entity type this enricher applies to.</typeparam>
+/// <remarks>
+/// Register via <c>builder.AddEntityLoggingScopeEnricher&lt;TEntity, TEnricher&gt;()</c>. Enrichers are resolved
+/// as singletons, may be invoked concurrently, and run synchronously on the hot path.
+/// </remarks>
+public interface IEntityLoggingScopeEnricher<TEntity>
+    where TEntity : IKubernetesObject<V1ObjectMeta>
+{
+    /// <summary>Adds properties to the logging scope being built for <typeparamref name="TEntity"/>.</summary>
+    /// <param name="entity">The concrete entity the scope is being created for.</param>
+    /// <param name="phase">The pipeline stage in which the scope is being created.</param>
+    /// <param name="properties">The properties contributed by this enricher.</param>
+    void Enrich(TEntity entity, EntityLoggingPhase phase, IDictionary<string, object> properties);
+}

--- a/src/KubeOps.Operator/Builder/OperatorBuilder.cs
+++ b/src/KubeOps.Operator/Builder/OperatorBuilder.cs
@@ -343,6 +343,11 @@ internal sealed class OperatorBuilder : IOperatorBuilder
         Services.AddSingleton(typeof(IEntityLabelSelector<>), typeof(DefaultEntityLabelSelector<>));
         Services.AddSingleton(typeof(IEntityFieldSelector<>), typeof(DefaultEntityFieldSelector<>));
 
+        // The factory is the public scope-creation boundary. It delegates enrichment to a no-op pipeline
+        // when no IEntityLoggingScopeEnricher<TEntity> is registered.
+        Services.TryAddSingleton(typeof(EntityLoggingScopeEnricherPipeline<>));
+        Services.TryAddSingleton(typeof(IEntityLoggingScopeFactory<>), typeof(EntityLoggingScopeFactory<>));
+
         if (Settings.LeaderElectionType == LeaderElectionType.Single)
         {
             Services.AddLeaderElection();

--- a/src/KubeOps.Operator/Logging/EntityLoggingScope.cs
+++ b/src/KubeOps.Operator/Logging/EntityLoggingScope.cs
@@ -7,6 +7,7 @@ using System.Collections;
 using k8s;
 using k8s.Models;
 
+using KubeOps.Abstractions.Logging;
 using KubeOps.Abstractions.Reconciliation;
 
 namespace KubeOps.Operator.Logging;
@@ -31,47 +32,30 @@ public sealed record EntityLoggingScope : IReadOnlyCollection<KeyValuePair<strin
     private IReadOnlyDictionary<string, object> Values { get; }
 
     /// <summary>
-    /// Creates a new instance of <see cref="EntityLoggingScope"/> for the provided Kubernetes entity and event type.
+    /// Creates an unenriched logging scope for the provided Kubernetes watch event.
     /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the Kubernetes entity. Must implement <see cref="IKubernetesObject{V1ObjectMeta}"/>.
-    /// </typeparam>
-    /// <param name="eventType">
-    /// The type of the watch event for the entity (e.g., Added, Modified, Deleted, or Bookmark).
-    /// </param>
-    /// <param name="entity">
-    /// The Kubernetes entity associated with the logging scope. This includes metadata such as Kind, Namespace, Name, UID, and ResourceVersion.
-    /// </param>
-    /// <returns>
-    /// A new <see cref="EntityLoggingScope"/> instance containing contextual key-value pairs
-    /// related to the event type and the provided Kubernetes entity.
-    /// </returns>
+    /// <typeparam name="TEntity">The Kubernetes entity type.</typeparam>
+    /// <param name="eventType">The watch event type.</param>
+    /// <param name="entity">The entity associated with the event.</param>
+    /// <returns>A logging scope containing the built-in identification fields.</returns>
     public static EntityLoggingScope CreateFor<TEntity>(WatchEventType eventType, TEntity entity)
         where TEntity : IKubernetesObject<V1ObjectMeta>
-        => CreateLoggingScope(eventType.ToString(), ReconciliationTriggerSource.ApiServer, entity);
+        => CreateUnenriched(eventType.ToString(), ReconciliationTriggerSource.ApiServer, entity);
 
     /// <summary>
-    /// Creates a new instance of <see cref="EntityLoggingScope"/> for the given Kubernetes entity and reconciliation operation type.
+    /// Creates an unenriched logging scope for the provided reconciliation.
     /// </summary>
-    /// <typeparam name="TEntity">
-    /// The type of the Kubernetes entity. Must implement <see cref="IKubernetesObject{V1ObjectMeta}"/>.
-    /// </typeparam>
-    /// <param name="eventType">
-    /// The type of reconciliation operation for the entity (e.g., Added, Modified, or Deleted).
-    /// </param>
-    /// <param name="reconciliationTriggerSource">
-    /// The source of the reconciliation trigger (e.g., ApiServer, Operator). This provides additional context for the logging scope.
-    /// </param>
-    /// <param name="entity">
-    /// The Kubernetes entity associated with the logging scope. This includes metadata such as Kind, Namespace, Name, UID, and ResourceVersion.
-    /// </param>
-    /// <returns>
-    /// A new <see cref="EntityLoggingScope"/> instance containing contextual key-value pairs
-    /// related to the reconciliation operation type and the provided Kubernetes entity.
-    /// </returns>
-    public static EntityLoggingScope CreateFor<TEntity>(ReconciliationType eventType, ReconciliationTriggerSource reconciliationTriggerSource, TEntity entity)
+    /// <typeparam name="TEntity">The Kubernetes entity type.</typeparam>
+    /// <param name="eventType">The reconciliation operation type.</param>
+    /// <param name="reconciliationTriggerSource">The source that triggered the reconciliation.</param>
+    /// <param name="entity">The entity associated with the reconciliation.</param>
+    /// <returns>A logging scope containing the built-in identification fields.</returns>
+    public static EntityLoggingScope CreateFor<TEntity>(
+        ReconciliationType eventType,
+        ReconciliationTriggerSource reconciliationTriggerSource,
+        TEntity entity)
         where TEntity : IKubernetesObject<V1ObjectMeta>
-        => CreateLoggingScope(eventType.ToString(), reconciliationTriggerSource, entity);
+        => CreateUnenriched(eventType.ToString(), reconciliationTriggerSource, entity);
 
     /// <inheritdoc />
     public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
@@ -85,17 +69,46 @@ public sealed record EntityLoggingScope : IReadOnlyCollection<KeyValuePair<strin
     IEnumerator IEnumerable.GetEnumerator()
         => GetEnumerator();
 
-    private static EntityLoggingScope CreateLoggingScope<TEntity>(string eventType, ReconciliationTriggerSource triggerSource, TEntity entity)
+    internal static EntityLoggingScope Create<TEntity>(
+        string eventType,
+        ReconciliationTriggerSource triggerSource,
+        TEntity entity,
+        EntityLoggingPhase phase,
+        EntityLoggingScopeEnricherPipeline<TEntity> enrichers)
         where TEntity : IKubernetesObject<V1ObjectMeta>
-        => new(
-            new Dictionary<string, object>(7)
-            {
-                { "EventType", eventType },
-                { "ReconciliationTriggerSource", triggerSource },
-                { nameof(entity.Kind), entity.Kind },
-                { "Namespace", entity.Namespace() },
-                { "Name", entity.Name() },
-                { "Uid", entity.Uid() },
-                { "ResourceVersion", entity.ResourceVersion() },
-            });
+    {
+        var items = new Dictionary<string, object>(7);
+        SetBuiltInProperties(items, eventType, triggerSource, entity);
+
+        enrichers.Enrich(entity, phase, items);
+
+        return new(items);
+    }
+
+    private static EntityLoggingScope CreateUnenriched<TEntity>(
+        string eventType,
+        ReconciliationTriggerSource triggerSource,
+        TEntity entity)
+        where TEntity : IKubernetesObject<V1ObjectMeta>
+    {
+        var items = new Dictionary<string, object>(7);
+        SetBuiltInProperties(items, eventType, triggerSource, entity);
+        return new(items);
+    }
+
+    private static void SetBuiltInProperties<TEntity>(
+        IDictionary<string, object> items,
+        string eventType,
+        ReconciliationTriggerSource triggerSource,
+        TEntity entity)
+        where TEntity : IKubernetesObject<V1ObjectMeta>
+    {
+        items["EventType"] = eventType;
+        items["ReconciliationTriggerSource"] = triggerSource;
+        items[nameof(entity.Kind)] = entity.Kind;
+        items["Namespace"] = entity.Namespace();
+        items["Name"] = entity.Name();
+        items["Uid"] = entity.Uid();
+        items["ResourceVersion"] = entity.ResourceVersion();
+    }
 }

--- a/src/KubeOps.Operator/Logging/EntityLoggingScopeEnricherPipeline.cs
+++ b/src/KubeOps.Operator/Logging/EntityLoggingScopeEnricherPipeline.cs
@@ -1,0 +1,61 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Logging;
+
+using Microsoft.Extensions.Logging;
+
+namespace KubeOps.Operator.Logging;
+
+/// <summary>
+/// Applies registered enrichers in order (so the first enricher that contributes a key wins) and isolates
+/// individual failures so logging-scope enrichment cannot take down a watch or reconciliation.
+/// </summary>
+/// <typeparam name="TEntity">The entity type this pipeline enriches scopes for.</typeparam>
+internal sealed partial class EntityLoggingScopeEnricherPipeline<TEntity>(
+    IEnumerable<IEntityLoggingScopeEnricher<TEntity>> entityEnrichers,
+    ILogger<EntityLoggingScopeEnricherPipeline<TEntity>> logger)
+    where TEntity : IKubernetesObject<V1ObjectMeta>
+{
+    private readonly IEntityLoggingScopeEnricher<TEntity>[] _entityEnrichers = entityEnrichers.ToArray();
+
+    public void Enrich(TEntity entity, EntityLoggingPhase phase, IDictionary<string, object> items)
+    {
+        if (_entityEnrichers.Length == 0)
+        {
+            return;
+        }
+
+        var pendingItems = new Dictionary<string, object>();
+
+        foreach (var enricher in _entityEnrichers)
+        {
+            try
+            {
+                enricher.Enrich(entity, phase, pendingItems);
+                foreach (var item in pendingItems)
+                {
+                    items.TryAdd(item.Key, item.Value);
+                }
+            }
+            catch (Exception exception)
+            {
+                LogEnricherFailed(exception, enricher.GetType().FullName ?? enricher.GetType().Name);
+            }
+            finally
+            {
+                pendingItems.Clear();
+            }
+        }
+    }
+
+    [LoggerMessage(
+        EventId = 0,
+        Level = LogLevel.Warning,
+        Message = "Entity logging scope enricher '{Enricher}' threw and was skipped.")]
+    private partial void LogEnricherFailed(Exception exception, string enricher);
+}

--- a/src/KubeOps.Operator/Logging/EntityLoggingScopeFactory.cs
+++ b/src/KubeOps.Operator/Logging/EntityLoggingScopeFactory.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Logging;
+using KubeOps.Abstractions.Reconciliation;
+
+namespace KubeOps.Operator.Logging;
+
+internal sealed class EntityLoggingScopeFactory<TEntity>(
+    EntityLoggingScopeEnricherPipeline<TEntity> enrichers)
+    : IEntityLoggingScopeFactory<TEntity>
+    where TEntity : IKubernetesObject<V1ObjectMeta>
+{
+    public EntityLoggingScope CreateFor(WatchEventType eventType, TEntity entity)
+        => EntityLoggingScope.Create(
+            eventType.ToString(),
+            ReconciliationTriggerSource.ApiServer,
+            entity,
+            EntityLoggingPhase.Watch,
+            enrichers);
+
+    public EntityLoggingScope CreateFor(
+        ReconciliationType eventType,
+        ReconciliationTriggerSource reconciliationTriggerSource,
+        TEntity entity)
+        => EntityLoggingScope.Create(
+            eventType.ToString(),
+            reconciliationTriggerSource,
+            entity,
+            EntityLoggingPhase.Reconcile,
+            enrichers);
+}

--- a/src/KubeOps.Operator/Logging/IEntityLoggingScopeFactory.cs
+++ b/src/KubeOps.Operator/Logging/IEntityLoggingScopeFactory.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Reconciliation;
+
+namespace KubeOps.Operator.Logging;
+
+/// <summary>
+/// Creates consistently enriched logging scopes for watch events and reconciliations of
+/// <typeparamref name="TEntity"/>.
+/// </summary>
+/// <typeparam name="TEntity">The Kubernetes entity type the factory creates scopes for.</typeparam>
+public interface IEntityLoggingScopeFactory<TEntity>
+    where TEntity : IKubernetesObject<V1ObjectMeta>
+{
+    /// <summary>Creates a logging scope for a Kubernetes watch event.</summary>
+    /// <param name="eventType">The watch event type.</param>
+    /// <param name="entity">The entity associated with the event.</param>
+    /// <returns>The enriched logging scope.</returns>
+    EntityLoggingScope CreateFor(WatchEventType eventType, TEntity entity);
+
+    /// <summary>Creates a logging scope for a reconciliation.</summary>
+    /// <param name="eventType">The reconciliation operation type.</param>
+    /// <param name="reconciliationTriggerSource">The source that triggered the reconciliation.</param>
+    /// <param name="entity">The entity being reconciled.</param>
+    /// <returns>The enriched logging scope.</returns>
+    EntityLoggingScope CreateFor(
+        ReconciliationType eventType,
+        ReconciliationTriggerSource reconciliationTriggerSource,
+        TEntity entity);
+}

--- a/src/KubeOps.Operator/Queue/EntityQueueBackgroundService{TEntity}.cs
+++ b/src/KubeOps.Operator/Queue/EntityQueueBackgroundService{TEntity}.cs
@@ -66,6 +66,7 @@ public class EntityQueueBackgroundService<TEntity>(
     IReconciler<TEntity> reconciler,
     IEntityReconcileCoordinator<TEntity> coordinator,
     ILogger<EntityQueueBackgroundService<TEntity>> logger,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     OperatorMetrics? metrics = null) : RestartableHostedService, IEntityQueueConsumer<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {
@@ -216,7 +217,11 @@ public class EntityQueueBackgroundService<TEntity>(
     private async Task ProcessEntryAsync(QueueEntry<TEntity> entry, CancellationToken cancellationToken)
     {
         using var activity = activitySource.StartActivity($"""Processing queued "{entry.ReconciliationType}" event for "{entry.Entity.ToIdentifierString()}".""", ActivityKind.Consumer);
-        using var scope = logger.BeginScope(EntityLoggingScope.CreateFor(entry.ReconciliationType, entry.ReconciliationTriggerSource, entry.Entity));
+        using var scope = logger.BeginScope(
+            scopeFactory.CreateFor(
+                entry.ReconciliationType,
+                entry.ReconciliationTriggerSource,
+                entry.Entity));
 
         try
         {

--- a/src/KubeOps.Operator/Queue/LeaderAwareEntityQueueBackgroundService{TEntity}.cs
+++ b/src/KubeOps.Operator/Queue/LeaderAwareEntityQueueBackgroundService{TEntity}.cs
@@ -12,6 +12,7 @@ using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
 using KubeOps.Operator.LeaderElection;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 
 using Microsoft.Extensions.Logging;
@@ -55,6 +56,7 @@ public class LeaderAwareEntityQueueBackgroundService<TEntity>(
     IEntityReconcileCoordinator<TEntity> coordinator,
     ILogger<LeaderAwareEntityQueueBackgroundService<TEntity>> logger,
     LeaderElector elector,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     OperatorMetrics? metrics = null)
     : EntityQueueBackgroundService<TEntity>(
         activitySource,
@@ -64,6 +66,7 @@ public class LeaderAwareEntityQueueBackgroundService<TEntity>(
         reconciler,
         coordinator,
         logger,
+        scopeFactory,
         metrics), ILeaderAwareEntityQueueConsumer<TEntity>
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {

--- a/src/KubeOps.Operator/Queue/ScopeAwareEntityQueueBackgroundService{TEntity}.cs
+++ b/src/KubeOps.Operator/Queue/ScopeAwareEntityQueueBackgroundService{TEntity}.cs
@@ -11,6 +11,7 @@ using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.LeaderElection;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 
 using Microsoft.Extensions.Logging;
@@ -32,6 +33,7 @@ public class ScopeAwareEntityQueueBackgroundService<TEntity>(
     IEntityReconcileCoordinator<TEntity> coordinator,
     ILogger<ScopeAwareEntityQueueBackgroundService<TEntity>> logger,
     ILeadershipScope leadershipScope,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     OperatorMetrics? metrics = null)
     : EntityQueueBackgroundService<TEntity>(
         activitySource,
@@ -41,6 +43,7 @@ public class ScopeAwareEntityQueueBackgroundService<TEntity>(
         reconciler,
         coordinator,
         logger,
+        scopeFactory,
         metrics)
     where TEntity : IKubernetesObject<V1ObjectMeta>
 {

--- a/src/KubeOps.Operator/Watcher/LeaderAwareResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/LeaderAwareResourceWatcher{TEntity}.cs
@@ -12,6 +12,7 @@ using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Entities;
 using KubeOps.KubernetesClient;
 using KubeOps.Operator.LeaderElection;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 using KubeOps.Operator.Queue;
 
@@ -31,6 +32,7 @@ public class LeaderAwareResourceWatcher<TEntity>(
     IEntityFieldSelector<TEntity> fieldSelector,
     IKubernetesClient client,
     LeaderElector elector,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     string cachePartition = "",
     OperatorMetrics? metrics = null)
     : ResourceWatcher<TEntity>(
@@ -42,6 +44,7 @@ public class LeaderAwareResourceWatcher<TEntity>(
         labelSelector,
         fieldSelector,
         client,
+        scopeFactory,
         cachePartition,
         metrics)
     where TEntity : IKubernetesObject<V1ObjectMeta>

--- a/src/KubeOps.Operator/Watcher/LeaderAwareSharedResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/LeaderAwareSharedResourceWatcher{TEntity}.cs
@@ -11,6 +11,7 @@ using k8s.Models;
 using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Entities;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 using KubeOps.Operator.Queue;
 
@@ -36,6 +37,7 @@ internal sealed class LeaderAwareSharedResourceWatcher<TEntity>(
     IKubernetesClient client,
     LeaderElector elector,
     SharedPipelineDispatcher<TEntity> dispatcher,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     OperatorMetrics? metrics = null)
     : LeaderAwareResourceWatcher<TEntity>(
         activitySource,
@@ -47,6 +49,7 @@ internal sealed class LeaderAwareSharedResourceWatcher<TEntity>(
         fieldSelector,
         client,
         elector,
+        scopeFactory,
         cachePartition: string.Empty,
         metrics)
     where TEntity : IKubernetesObject<V1ObjectMeta>

--- a/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ResourceWatcher{TEntity}.cs
@@ -36,6 +36,7 @@ public class ResourceWatcher<TEntity>(
     IEntityLabelSelector<TEntity> labelSelector,
     IEntityFieldSelector<TEntity> fieldSelector,
     IKubernetesClient client,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     string cachePartition = "",
     OperatorMetrics? metrics = null)
     : RestartableHostedService, ISharedWatchDedup<TEntity>
@@ -181,7 +182,7 @@ public class ResourceWatcher<TEntity>(
                                    cancellationToken: cancellationToken))
                 {
                     using var activity = activitySource.StartActivity($"""processing "{type}" event""", ActivityKind.Consumer);
-                    using var scope = logger.BeginScope(EntityLoggingScope.CreateFor(type, entity));
+                    using var scope = logger.BeginScope(scopeFactory.CreateFor(type, entity));
 
                     metrics?.RecordWatchEvent(typeof(TEntity).Name, type.ToMetricString());
 

--- a/src/KubeOps.Operator/Watcher/ScopeAwareResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ScopeAwareResourceWatcher{TEntity}.cs
@@ -37,6 +37,7 @@ public class ScopeAwareResourceWatcher<TEntity>(
     IEntityFieldSelector<TEntity> fieldSelector,
     IKubernetesClient client,
     ILeadershipScope leadershipScope,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     string cachePartition = "",
     OperatorMetrics? metrics = null)
     : ResourceWatcher<TEntity>(
@@ -48,6 +49,7 @@ public class ScopeAwareResourceWatcher<TEntity>(
         labelSelector,
         fieldSelector,
         client,
+        scopeFactory,
         cachePartition,
         metrics)
     where TEntity : IKubernetesObject<V1ObjectMeta>

--- a/src/KubeOps.Operator/Watcher/ScopeAwareSharedResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/ScopeAwareSharedResourceWatcher{TEntity}.cs
@@ -11,6 +11,7 @@ using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Entities;
 using KubeOps.Abstractions.LeaderElection;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 using KubeOps.Operator.Queue;
 
@@ -37,6 +38,7 @@ internal sealed class ScopeAwareSharedResourceWatcher<TEntity>(
     IKubernetesClient client,
     ILeadershipScope leadershipScope,
     SharedPipelineDispatcher<TEntity> dispatcher,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     OperatorMetrics? metrics = null)
     : ScopeAwareResourceWatcher<TEntity>(
         activitySource,
@@ -48,6 +50,7 @@ internal sealed class ScopeAwareSharedResourceWatcher<TEntity>(
         fieldSelector,
         client,
         leadershipScope,
+        scopeFactory,
         cachePartition: string.Empty,
         metrics)
     where TEntity : IKubernetesObject<V1ObjectMeta>

--- a/src/KubeOps.Operator/Watcher/SharedResourceWatcher{TEntity}.cs
+++ b/src/KubeOps.Operator/Watcher/SharedResourceWatcher{TEntity}.cs
@@ -10,6 +10,7 @@ using k8s.Models;
 using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Entities;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 using KubeOps.Operator.Queue;
 
@@ -39,6 +40,7 @@ internal sealed class SharedResourceWatcher<TEntity>(
     IEntityFieldSelector<TEntity> fieldSelector,
     IKubernetesClient client,
     SharedPipelineDispatcher<TEntity> dispatcher,
+    IEntityLoggingScopeFactory<TEntity> scopeFactory,
     OperatorMetrics? metrics = null)
     : ResourceWatcher<TEntity>(
         activitySource,
@@ -49,6 +51,7 @@ internal sealed class SharedResourceWatcher<TEntity>(
         labelSelector,
         fieldSelector,
         client,
+        scopeFactory,
         cachePartition: string.Empty,
         metrics)
     where TEntity : IKubernetesObject<V1ObjectMeta>

--- a/test/KubeOps.Operator.Test/Builder/OperatorBuilderRegistrationValidation.Test.cs
+++ b/test/KubeOps.Operator.Test/Builder/OperatorBuilderRegistrationValidation.Test.cs
@@ -607,15 +607,15 @@ public sealed class OperatorBuilderRegistrationValidationTest
     // Test doubles for a user-provided Custom watcher / queue consumer. Validation inspects the service
     // descriptors only (it never constructs these), so the null base arguments are never dereferenced.
     private sealed class CustomWatcher() : ResourceWatcher<V1OperatorIntegrationTestEntity>(
-        null!, null!, null!, null!, null!, null!, null!, null!);
+        null!, null!, null!, null!, null!, null!, null!, null!, null!);
 
     private sealed class CustomConsumer() : EntityQueueBackgroundService<V1OperatorIntegrationTestEntity>(
-        null!, null!, null!, null!, null!, null!, null!);
+        null!, null!, null!, null!, null!, null!, null!, null!);
 
     // A leadership-aware consumer (implements ILeaderAwareEntityQueueConsumer via the base class).
     private sealed class CustomLeaderAwareConsumer()
         : LeaderAwareEntityQueueBackgroundService<V1OperatorIntegrationTestEntity>(
-            null!, null!, null!, null!, null!, null!, null!, null!);
+            null!, null!, null!, null!, null!, null!, null!, null!, null!);
 
     // A custom queue that does NOT implement ISuspendableEntityQueue. Validation inspects the registration
     // descriptor only and never constructs it, so the members can throw.

--- a/test/KubeOps.Operator.Test/Logging/EntityLoggingScopeEnricher.Test.cs
+++ b/test/KubeOps.Operator.Test/Logging/EntityLoggingScopeEnricher.Test.cs
@@ -1,0 +1,482 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+using FluentAssertions;
+
+using k8s;
+using k8s.Models;
+
+using KubeOps.Abstractions.Builder;
+using KubeOps.Abstractions.Entities;
+using KubeOps.Abstractions.Logging;
+using KubeOps.Abstractions.Reconciliation;
+using KubeOps.KubernetesClient;
+using KubeOps.Operator.Builder;
+using KubeOps.Operator.Logging;
+using KubeOps.Operator.Queue;
+using KubeOps.Operator.Test.TestEntities;
+using KubeOps.Operator.Watcher;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace KubeOps.Operator.Test.Logging;
+
+[Trait("Area", "Logging")]
+public sealed class EntityLoggingScopeEnricherTest
+{
+    private static V1OperatorIntegrationTestEntity Entity => new("name", "username", "ns");
+
+    [Fact]
+    public void Pipeline_Applies_Registered_Enrichers()
+    {
+        var pipeline = Pipeline([
+            new SetTypedEnricher("first", _ => "value"),
+            new SetTypedEnricher("second", e => e.Metadata.Name),
+        ]);
+
+        var items = FreshItems();
+        pipeline.Enrich(Entity, EntityLoggingPhase.Reconcile, items);
+
+        items["first"].Should().Be("value");
+        items["second"].Should().Be("name");
+    }
+
+    [Fact]
+    public void Pipeline_Uses_First_Writer_Wins()
+    {
+        var pipeline = Pipeline([
+            new SetTypedEnricher("shared", _ => "first"),
+            new SetTypedEnricher("shared", _ => "second"),
+        ]);
+
+        var items = FreshItems();
+        pipeline.Enrich(Entity, EntityLoggingPhase.Reconcile, items);
+
+        items["shared"].Should().Be("first");
+    }
+
+    [Fact]
+    public void Enricher_Cannot_Override_Builtin_Key()
+    {
+        var pipeline = Pipeline([new SetTypedEnricher("Name", _ => "overridden")]);
+
+        var scope = Factory(pipeline).CreateFor(WatchEventType.Modified, Entity);
+        var items = scope.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        items["Name"].Should().Be("name");
+        items.Should().ContainKeys("EventType", "Kind", "Namespace", "Uid", "ResourceVersion");
+    }
+
+    [Theory]
+    [InlineData(EntityLoggingPhase.Watch)]
+    [InlineData(EntityLoggingPhase.Reconcile)]
+    public void Pipeline_Passes_The_Current_Phase_To_Enrichers(EntityLoggingPhase phase)
+    {
+        EntityLoggingPhase? observed = null;
+        var pipeline = Pipeline([
+            new DelegatingTypedEnricher<V1OperatorIntegrationTestEntity>((_, currentPhase, _) =>
+                observed = currentPhase),
+        ]);
+
+        pipeline.Enrich(Entity, phase, FreshItems());
+
+        observed.Should().Be(phase);
+    }
+
+    [Fact]
+    public void A_Throwing_Enricher_Is_Isolated_And_Following_Enrichers_Still_Run()
+    {
+        var pipeline = Pipeline([
+            new ThrowingAfterAddEnricher(),
+            new SetTypedEnricher("after", _ => "ran"),
+        ]);
+
+        var items = FreshItems();
+        var act = () => pipeline.Enrich(Entity, EntityLoggingPhase.Reconcile, items);
+
+        act.Should().NotThrow();
+        items.Should().NotContainKey("partial");
+        items["after"].Should().Be("ran");
+    }
+
+    [Fact]
+    public void CreateFor_Enriches_The_Watch_Scope()
+    {
+        var pipeline = Pipeline([new SetTypedEnricher("custom", _ => "value")]);
+
+        var scope = Factory(pipeline).CreateFor(WatchEventType.Added, Entity);
+
+        scope.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)["custom"].Should().Be("value");
+    }
+
+    [Fact]
+    public void CreateFor_With_Empty_Pipeline_Preserves_The_Unenriched_Scope()
+    {
+        var expected = EntityLoggingScope.CreateFor(
+            ReconciliationType.Modified,
+            ReconciliationTriggerSource.ApiServer,
+            Entity).ToDictionary();
+        var scope = Factory(Pipeline([])).CreateFor(
+            ReconciliationType.Modified,
+            ReconciliationTriggerSource.ApiServer,
+            Entity).ToDictionary();
+
+        scope.Should().Equal(expected);
+    }
+
+    [Fact]
+    public async Task ResourceWatcher_Forwards_The_Pipeline_To_The_Watch_Scope()
+    {
+        var entity = Entity;
+        var pipeline = Pipeline([new SetTypedEnricher("watch-custom", _ => "value")]);
+        var logger = new CapturingLogger<ResourceWatcher<V1OperatorIntegrationTestEntity>>();
+        var client = new Mock<IKubernetesClient>();
+        client
+            .Setup(c => c.WatchAsync<V1OperatorIntegrationTestEntity>(
+                "unit-test",
+                null,
+                null,
+                null,
+                true,
+                It.IsAny<CancellationToken>()))
+            .Returns<string?, string?, string?, string?, bool?, CancellationToken>(
+                (_, _, _, _, _, cancellationToken) => WatchOnce(entity, cancellationToken));
+
+        var cacheProvider = new Mock<IFusionCacheProvider>();
+        cacheProvider.Setup(c => c.GetCache(It.IsAny<string>())).Returns(Mock.Of<IFusionCache>());
+
+        await using var watcher = new ResourceWatcher<V1OperatorIntegrationTestEntity>(
+            new ActivitySource("test"),
+            logger,
+            cacheProvider.Object,
+            Mock.Of<ITimedEntityQueue<V1OperatorIntegrationTestEntity>>(),
+            new OperatorSettingsBuilder { Namespace = "unit-test" }.Build(),
+            new DefaultEntityLabelSelector<V1OperatorIntegrationTestEntity>(),
+            new DefaultEntityFieldSelector<V1OperatorIntegrationTestEntity>(),
+            client.Object,
+            scopeFactory: Factory(pipeline));
+
+        await watcher.StartAsync(TestContext.Current.CancellationToken);
+        var scope = await logger.ScopeCaptured.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await watcher.StopAsync(TestContext.Current.CancellationToken);
+
+        scope["watch-custom"].Should().Be("value");
+    }
+
+    [Fact]
+    public async Task EntityQueueBackgroundService_Enriches_The_Reconcile_Scope_With_The_Queued_Snapshot()
+    {
+        var queuedEntity = new V1ConfigMap
+        {
+            Kind = V1ConfigMap.KubeKind,
+            Metadata = new()
+            {
+                Name = "name",
+                NamespaceProperty = "ns",
+                Uid = Guid.NewGuid().ToString(),
+                ResourceVersion = "1",
+            },
+        };
+        var currentEntity = new V1ConfigMap
+        {
+            Kind = V1ConfigMap.KubeKind,
+            Metadata = new()
+            {
+                Name = "name",
+                NamespaceProperty = "ns",
+                Uid = queuedEntity.Metadata.Uid,
+                ResourceVersion = "2",
+            },
+        };
+        var enrichmentCount = 0;
+        var pipeline = new EntityLoggingScopeEnricherPipeline<V1ConfigMap>(
+            [new DelegatingTypedEnricher<V1ConfigMap>((entity, _, properties) =>
+            {
+                enrichmentCount++;
+                properties.TryAdd("reconcile-custom", entity.ResourceVersion());
+            })],
+            NullLogger<EntityLoggingScopeEnricherPipeline<V1ConfigMap>>.Instance);
+        var client = new Mock<IKubernetesClient>();
+        client
+            .Setup(c => c.GetAsync<V1ConfigMap>("name", "ns", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(currentEntity);
+        var reconciler = new Mock<IReconciler<V1ConfigMap>>();
+        reconciler
+            .Setup(r => r.Reconcile(It.IsAny<ReconciliationContext<V1ConfigMap>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ReconciliationResult<V1ConfigMap>.Success(currentEntity));
+
+        var logger = new ScopeRecordingLogger<EntityQueueBackgroundService<V1ConfigMap>>();
+        var settings = new OperatorSettingsBuilder().Build();
+        await using var service = new EntityQueueBackgroundService<V1ConfigMap>(
+            new ActivitySource("test"),
+            client.Object,
+            settings,
+            new SingleEntryQueue<V1ConfigMap>(
+                new(queuedEntity, ReconciliationType.Modified, ReconciliationTriggerSource.ApiServer, RetryCount: 0)),
+            reconciler.Object,
+            new EntityReconcileCoordinator<V1ConfigMap>(settings),
+            logger,
+            scopeFactory: new EntityLoggingScopeFactory<V1ConfigMap>(pipeline));
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+        var scope = await logger.StartingReconciliationScope.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+
+        scope["ResourceVersion"].Should().Be("1");
+        scope["reconcile-custom"].Should().Be("1");
+        enrichmentCount.Should().Be(1);
+        reconciler.Verify(
+            r => r.Reconcile(
+                It.Is<ReconciliationContext<V1ConfigMap>>(c => ReferenceEquals(c.Entity, currentEntity)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EntityQueueBackgroundService_Keeps_NotFound_Skip_Log_In_The_Snapshot_Scope()
+    {
+        var queuedEntity = new V1ConfigMap
+        {
+            Kind = V1ConfigMap.KubeKind,
+            Metadata = new()
+            {
+                Name = "name",
+                NamespaceProperty = "ns",
+                Uid = Guid.NewGuid().ToString(),
+                ResourceVersion = "1",
+            },
+        };
+        var pipeline = new EntityLoggingScopeEnricherPipeline<V1ConfigMap>(
+            [new DelegatingTypedEnricher<V1ConfigMap>((entity, _, properties) =>
+                properties.TryAdd("reconcile-custom", entity.ResourceVersion()))],
+            NullLogger<EntityLoggingScopeEnricherPipeline<V1ConfigMap>>.Instance);
+        var client = new Mock<IKubernetesClient>();
+        client
+            .Setup(c => c.GetAsync<V1ConfigMap>("name", "ns", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((V1ConfigMap?)null);
+        var logger = new ScopeRecordingLogger<EntityQueueBackgroundService<V1ConfigMap>>();
+        var settings = new OperatorSettingsBuilder().Build();
+        await using var service = new EntityQueueBackgroundService<V1ConfigMap>(
+            new ActivitySource("test"),
+            client.Object,
+            settings,
+            new SingleEntryQueue<V1ConfigMap>(
+                new(queuedEntity, ReconciliationType.Modified, ReconciliationTriggerSource.ApiServer, RetryCount: 0)),
+            Mock.Of<IReconciler<V1ConfigMap>>(),
+            new EntityReconcileCoordinator<V1ConfigMap>(settings),
+            logger,
+            scopeFactory: new EntityLoggingScopeFactory<V1ConfigMap>(pipeline));
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+        var scope = await logger.NotFoundScope.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        await service.StopAsync(TestContext.Current.CancellationToken);
+
+        scope["ResourceVersion"].Should().Be("1");
+        scope["reconcile-custom"].Should().Be("1");
+    }
+
+    [Fact]
+    public void Builder_Registers_A_Factory_That_Composes_The_Configured_Enrichers()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var builder = new OperatorBuilder(services, new OperatorSettingsBuilder().WithName("test").Build());
+
+        builder.AddEntityLoggingScopeEnricher<V1OperatorIntegrationTestEntity, TypedRegisteredEnricher>();
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>();
+        var items = factory
+            .CreateFor(ReconciliationType.Modified, ReconciliationTriggerSource.ApiServer, Entity)
+            .ToDictionary();
+
+        items.Should().ContainKey("registered-typed");
+    }
+
+    private static Dictionary<string, object> FreshItems() => new();
+
+    private static async IAsyncEnumerable<(WatchEventType Type, V1OperatorIntegrationTestEntity Entity)> WatchOnce(
+        V1OperatorIntegrationTestEntity entity,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return (WatchEventType.Modified, entity);
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    private static EntityLoggingScopeEnricherPipeline<V1OperatorIntegrationTestEntity> Pipeline(
+        IEnumerable<IEntityLoggingScopeEnricher<V1OperatorIntegrationTestEntity>> enrichers)
+        => new(enrichers, NullLogger<EntityLoggingScopeEnricherPipeline<V1OperatorIntegrationTestEntity>>.Instance);
+
+    private static EntityLoggingScopeFactory<V1OperatorIntegrationTestEntity> Factory(
+        EntityLoggingScopeEnricherPipeline<V1OperatorIntegrationTestEntity> pipeline)
+        => new(pipeline);
+
+    private sealed class ThrowingAfterAddEnricher
+        : IEntityLoggingScopeEnricher<V1OperatorIntegrationTestEntity>
+    {
+        public void Enrich(
+            V1OperatorIntegrationTestEntity entity,
+            EntityLoggingPhase phase,
+            IDictionary<string, object> properties)
+        {
+            properties.TryAdd("partial", "discarded");
+            throw new InvalidOperationException("boom");
+        }
+    }
+
+    private sealed class SetTypedEnricher(string key, Func<V1OperatorIntegrationTestEntity, object> value)
+        : IEntityLoggingScopeEnricher<V1OperatorIntegrationTestEntity>
+    {
+        public void Enrich(
+            V1OperatorIntegrationTestEntity entity,
+            EntityLoggingPhase phase,
+            IDictionary<string, object> properties) =>
+            properties.TryAdd(key, value(entity));
+    }
+
+    private sealed class DelegatingTypedEnricher<TEntity>(
+        Action<TEntity, EntityLoggingPhase, IDictionary<string, object>> action)
+        : IEntityLoggingScopeEnricher<TEntity>
+        where TEntity : IKubernetesObject<V1ObjectMeta>
+    {
+        public void Enrich(
+            TEntity entity,
+            EntityLoggingPhase phase,
+            IDictionary<string, object> properties) =>
+            action(entity, phase, properties);
+    }
+
+    private sealed class TypedRegisteredEnricher : IEntityLoggingScopeEnricher<V1OperatorIntegrationTestEntity>
+    {
+        public void Enrich(
+            V1OperatorIntegrationTestEntity entity,
+            EntityLoggingPhase phase,
+            IDictionary<string, object> properties) =>
+            properties.TryAdd("registered-typed", true);
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public TaskCompletionSource<IReadOnlyDictionary<string, object>> ScopeCaptured { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            if (state is IEnumerable<KeyValuePair<string, object>> values)
+            {
+                ScopeCaptured.TrySetResult(values.ToDictionary());
+            }
+
+            return EmptyDisposable.Instance;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
+
+    private sealed class ScopeRecordingLogger<T> : ILogger<T>
+    {
+        private readonly AsyncLocal<IReadOnlyDictionary<string, object>?> _currentScope = new();
+
+        public TaskCompletionSource<IReadOnlyDictionary<string, object>> StartingReconciliationScope { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource<IReadOnlyDictionary<string, object>> NotFoundScope { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            var previousScope = _currentScope.Value;
+            _currentScope.Value = state is IEnumerable<KeyValuePair<string, object>> values
+                ? values.ToDictionary()
+                : null;
+            return new ScopeRestorer(() => _currentScope.Value = previousScope);
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (_currentScope.Value is not { } scope)
+            {
+                return;
+            }
+
+            var message = formatter(state, exception);
+            if (message.StartsWith("Starting reconciliation", StringComparison.Ordinal))
+            {
+                StartingReconciliationScope.TrySetResult(scope);
+            }
+
+            if (message.Contains("was not found", StringComparison.Ordinal))
+            {
+                NotFoundScope.TrySetResult(scope);
+            }
+        }
+    }
+
+    private sealed class ScopeRestorer(Action restore) : IDisposable
+    {
+        public void Dispose() => restore();
+    }
+
+    private sealed class SingleEntryQueue<TEntity>(QueueEntry<TEntity> entry) : ITimedEntityQueue<TEntity>
+        where TEntity : IKubernetesObject<V1ObjectMeta>
+    {
+        public Task<bool> Enqueue(
+            TEntity entity,
+            ReconciliationType type,
+            ReconciliationTriggerSource reconciliationTriggerSource,
+            TimeSpan queueIn,
+            int retryCount,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+
+        public async IAsyncEnumerator<QueueEntry<TEntity>> GetAsyncEnumerator(
+            CancellationToken cancellationToken = default)
+        {
+            yield return entry;
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class EmptyDisposable : IDisposable
+    {
+        public static EmptyDisposable Instance { get; } = new();
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/KubeOps.Operator.Test/Queue/EntityQueueBackgroundService.Test.cs
+++ b/test/KubeOps.Operator.Test/Queue/EntityQueueBackgroundService.Test.cs
@@ -11,6 +11,7 @@ using k8s.Models;
 using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 using KubeOps.Operator.Queue;
 
@@ -163,6 +164,7 @@ public sealed class EntityQueueBackgroundServiceTest
             reconcilerMock.Object,
             new EntityReconcileCoordinator<V1ConfigMap>(effectiveSettings),
             Mock.Of<ILogger<EntityQueueBackgroundService<V1ConfigMap>>>(),
+            Mock.Of<IEntityLoggingScopeFactory<V1ConfigMap>>(),
             metrics);
 
         // Keep the drain bound short so tests that intentionally block a worker across StopAsync/dispose don't
@@ -317,7 +319,8 @@ public sealed class EntityQueueBackgroundServiceTest
             queue,
             reconcilerMock.Object,
             new EntityReconcileCoordinator<V1ConfigMap>(settings),
-            Mock.Of<ILogger<EntityQueueBackgroundService<V1ConfigMap>>>())
+            Mock.Of<ILogger<EntityQueueBackgroundService<V1ConfigMap>>>(),
+            Mock.Of<IEntityLoggingScopeFactory<V1ConfigMap>>())
         {
             // The BarrierQueue ignores cancellation, so bound the stop/dispose drain short.
             DrainGracePeriod = TimeSpan.FromMilliseconds(200),

--- a/test/KubeOps.Operator.Test/Queue/LeaderAwareEntityQueueBackgroundService.Test.cs
+++ b/test/KubeOps.Operator.Test/Queue/LeaderAwareEntityQueueBackgroundService.Test.cs
@@ -12,6 +12,7 @@ using k8s.Models;
 using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Metrics;
 using KubeOps.Operator.Queue;
 using KubeOps.Operator.Test.TestEntities;
@@ -418,6 +419,7 @@ public sealed class LeaderAwareEntityQueueBackgroundServiceTest
                     new OperatorSettingsBuilder { Namespace = "unit-test" }.Build()),
                 logger,
                 elector,
+                Mock.Of<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>(),
                 metrics)
         {
             _elector = elector;

--- a/test/KubeOps.Operator.Test/Queue/ScopeAwareEntityQueueBackgroundService.Test.cs
+++ b/test/KubeOps.Operator.Test/Queue/ScopeAwareEntityQueueBackgroundService.Test.cs
@@ -13,6 +13,7 @@ using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.LeaderElection;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Queue;
 using KubeOps.Operator.Test.TestEntities;
 
@@ -175,11 +176,12 @@ public sealed class ScopeAwareEntityQueueBackgroundServiceTest
             reconciler,
             Mock.Of<IEntityReconcileCoordinator<V1OperatorIntegrationTestEntity>>(),
             Mock.Of<ILogger<ScopeAwareEntityQueueBackgroundService<V1OperatorIntegrationTestEntity>>>(),
-            leadershipScope)
+            leadershipScope,
+            Mock.Of<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>())
     {
         public Task<ReconciliationResult<V1OperatorIntegrationTestEntity>> InvokeReconcileSingleAsync(
             QueueEntry<V1OperatorIntegrationTestEntity> entry,
-            CancellationToken cancellationToken)
-            => ReconcileSingleAsync(entry, cancellationToken);
+            CancellationToken cancellationToken) =>
+            ReconcileSingleAsync(entry, cancellationToken);
     }
 }

--- a/test/KubeOps.Operator.Test/Watcher/LeaderAwareResourceWatcher.Test.cs
+++ b/test/KubeOps.Operator.Test/Watcher/LeaderAwareResourceWatcher.Test.cs
@@ -12,6 +12,7 @@ using KubeOps.Abstractions.Builder;
 using KubeOps.Abstractions.Entities;
 using KubeOps.KubernetesClient;
 using KubeOps.Operator.Constants;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Queue;
 using KubeOps.Operator.Test.TestEntities;
 using KubeOps.Operator.Watcher;
@@ -275,7 +276,8 @@ public sealed class LeaderAwareResourceWatcherTest
                 new DefaultEntityLabelSelector<V1OperatorIntegrationTestEntity>(),
                 new DefaultEntityFieldSelector<V1OperatorIntegrationTestEntity>(),
                 client,
-                elector)
+                elector,
+                Mock.Of<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>())
         {
             _elector = elector;
         }

--- a/test/KubeOps.Operator.Test/Watcher/ResourceWatcher{TEntity}.Test.cs
+++ b/test/KubeOps.Operator.Test/Watcher/ResourceWatcher{TEntity}.Test.cs
@@ -744,7 +744,16 @@ public sealed class ResourceWatcherTest
         IEntityLabelSelector<V1OperatorIntegrationTestEntity> labelSelector,
         IEntityFieldSelector<V1OperatorIntegrationTestEntity> fieldSelector,
         IKubernetesClient client)
-        : ResourceWatcher<V1OperatorIntegrationTestEntity>(activitySource, logger, cacheProvider, queue, settings, labelSelector, fieldSelector, client)
+        : ResourceWatcher<V1OperatorIntegrationTestEntity>(
+            activitySource,
+            logger,
+            cacheProvider,
+            queue,
+            settings,
+            labelSelector,
+            fieldSelector,
+            client,
+            Mock.Of<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>())
     {
         public Task InvokeOnEventAsync(WatchEventType eventType, V1OperatorIntegrationTestEntity entity, CancellationToken cancellationToken)
             => OnEventAsync(eventType, entity, cancellationToken);

--- a/test/KubeOps.Operator.Test/Watcher/ScopeAwareResourceWatcher.Test.cs
+++ b/test/KubeOps.Operator.Test/Watcher/ScopeAwareResourceWatcher.Test.cs
@@ -16,6 +16,7 @@ using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
 using KubeOps.Operator.Builder;
 using KubeOps.Operator.Constants;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Queue;
 using KubeOps.Operator.Test.TestEntities;
 using KubeOps.Operator.Watcher;
@@ -468,7 +469,8 @@ public sealed class ScopeAwareResourceWatcherTest
             labelSelector,
             fieldSelector,
             client,
-            leadershipScope)
+            leadershipScope,
+            Mock.Of<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>())
     {
         public Task InvokeOnEventAsync(
             WatchEventType eventType,

--- a/test/KubeOps.Operator.Test/Watcher/ScopeAwareSharedResourceWatcher.Test.cs
+++ b/test/KubeOps.Operator.Test/Watcher/ScopeAwareSharedResourceWatcher.Test.cs
@@ -15,6 +15,7 @@ using KubeOps.Abstractions.Entities;
 using KubeOps.Abstractions.LeaderElection;
 using KubeOps.Abstractions.Reconciliation;
 using KubeOps.KubernetesClient;
+using KubeOps.Operator.Logging;
 using KubeOps.Operator.Queue;
 using KubeOps.Operator.Test.TestEntities;
 using KubeOps.Operator.Watcher;
@@ -120,7 +121,8 @@ public sealed class ScopeAwareSharedResourceWatcherTest
             Mock.Of<IEntityFieldSelector<V1OperatorIntegrationTestEntity>>(),
             Mock.Of<IKubernetesClient>(),
             Mock.Of<ILeadershipScope>(),
-            dispatcher);
+            dispatcher,
+            Mock.Of<IEntityLoggingScopeFactory<V1OperatorIntegrationTestEntity>>());
     }
 
     private static V1OperatorIntegrationTestEntity CreateEntity() =>


### PR DESCRIPTION
## Summary

Introduce `IEntityLoggingScopeFactory<TEntity>` for creating structured entity logging scopes with optional enrichment. Update critical operator components (`ResourceWatcher<TEntity>`, `EntityQueueBackgroundService<TEntity>`, etc.) to accept the factory. Documentation and test updates ensure clarity on usage.

## Breaking changes

- Add `IEntityLoggingScopeFactory<TEntity>` to constructor parameters of watchers and queue services.
- Custom constructors for these components must resolve and provide the factory.
- New `EntityLoggingScopeEnricherPipeline<TEntity>` type for enriching scopes; automatically registered as no-op when no enrichers are present.