### PR TITLE
feat(cli/rbac): introduce namespaced RBAC generation support

### DIFF
--- a/docs/docs/operator/aspire/kubernetes-operator-model.mdx
+++ b/docs/docs/operator/aspire/kubernetes-operator-model.mdx
@@ -122,6 +122,11 @@ publish.SkipCrds();
 publish.SkipRbac();
 ```
 
+RBAC scope is inferred from the operator project's `AddKubernetesOperator` configuration. A constant
+`OperatorSettings.Namespace` produces a `Role` and `RoleBinding`; an unset namespace produces cluster-wide RBAC.
+For a namespaced operator, set the existing publish `Namespace` option to the same value. No separate Aspire RBAC
+option is required.
+
 With a Kubernetes environment, `aspire publish` writes the generated Helm chart. `aspire deploy` uses the same Kubernetes environment and deployment engine to install it. The KubeOps integration hooks into Aspire's Kubernetes resource customization path (`PublishAsKubernetesService`) rather than running a separate KubeOps deployment.
 
 The integration filters KubeOps' generated `Deployment` out of the additional resource set because Aspire owns the workload. KubeOps deployment settings such as replicas, termination grace period, environment variables, resource requirements, `POD_NAMESPACE`, and the service account are merged into the Aspire-owned deployment instead. The chart therefore deploys one operator deployment, not a service-only placeholder and not a duplicate operator.

--- a/docs/docs/operator/cli.mdx
+++ b/docs/docs/operator/cli.mdx
@@ -108,6 +108,21 @@ Common options:
 Generated CRDs explicitly use `conversion.strategy: None` unless a conversion webhook is registered for the CRD.
 For registered conversion webhooks, the strategy is `Webhook` and includes the webhook client configuration.
 
+### Automatic RBAC Scope
+
+The generator reads the `AddKubernetesOperator` configuration from the project source. If
+`OperatorSettings.Namespace` is assigned a compile-time constant, it emits a `Role` and `RoleBinding` in that
+namespace. If no namespace is assigned, it emits the existing `ClusterRole` and `ClusterRoleBinding`.
+
+```csharp
+builder.Services.AddKubernetesOperator(settings =>
+    settings.Namespace = "tenant-a");
+```
+
+No additional CLI option is needed. Runtime-derived or indirect namespace values cannot be evaluated without running
+application code, so the CLI warns and falls back to cluster-wide RBAC. When using `--namespace` together with a
+statically configured watch namespace, both values must match.
+
 ## Cluster Information
 
 The `version` command shows information about your current Kubernetes cluster:

--- a/docs/docs/operator/deployment.mdx
+++ b/docs/docs/operator/deployment.mdx
@@ -59,6 +59,21 @@ This will:
 - Install CRDs
 - Set up any required configurations
 
+### Namespaced Operators
+
+When `OperatorSettings.Namespace` is assigned a compile-time constant, generated manifests use that namespace for
+both the operator deployment and its `Role`/`RoleBinding`. The namespace must already exist; KubeOps does not generate
+a `Namespace` object for this case.
+
+```csharp
+builder.Services.AddKubernetesOperator(settings =>
+    settings.Namespace = "tenant-a");
+```
+
+The initial implementation intentionally keeps the deployment and watch namespace identical. An explicit CLI
+`--namespace` value must therefore match the configured watch namespace. Operators without a configured namespace
+retain the existing cluster-wide RBAC and generated `<operator>-system` namespace.
+
 ## Generated Deployment Files
 
 KubeOps generates the following files in your config directory:

--- a/docs/docs/operator/rbac.mdx
+++ b/docs/docs/operator/rbac.mdx
@@ -21,6 +21,29 @@ Kubernetes RBAC works through four main resources:
 
 When you generate installation files for your operator (via the [CLI](./cli) or as part of the [build](./build-customization)), KubeOps automatically creates the necessary RBAC configurations for the operator's service account. These configurations define what resources and operations your operator is allowed to perform and are applied as part of the [deployment](./deployment).
 
+### Automatic RBAC Scope
+
+KubeOps derives the generated RBAC scope from the existing operator configuration. A compile-time constant namespace
+produces a namespaced `Role` and `RoleBinding`:
+
+```csharp
+builder.Services.AddKubernetesOperator(settings =>
+    settings.Namespace = "tenant-a");
+```
+
+When `Namespace` is not configured, KubeOps generates the existing cluster-wide `ClusterRole` and
+`ClusterRoleBinding`. No separate RBAC option is required.
+
+The CLI performs static analysis and does not execute application startup code. Namespace values loaded from runtime
+configuration or assigned through an external configuration method cannot be resolved safely. In those cases, the
+CLI prints a warning and retains cluster-wide RBAC for compatibility. String literals, `const string` values, direct
+property assignment, and `WithNamespace` are supported.
+
+The initial namespaced generation support deploys the operator into the watched namespace. If the CLI `--namespace`
+option is supplied, it must match `OperatorSettings.Namespace`. Cluster-scoped entities and non-resource URL rules
+cannot be granted by a namespaced `Role` and cause generation to fail. For string-based `GenericRbacAttribute` rules,
+make sure every referenced resource is namespaced.
+
 :::note[Local Development]
 During local development, you typically use an admin account that has full cluster access. Therefore, RBAC restrictions don't apply, and you don't need to worry about permissions. However, it's still good practice to define the required RBAC rules for production use.
 :::
@@ -139,6 +162,8 @@ KubeOps automatically adds default RBAC rules for:
    - Operator has more access than needed
    - Security risks from broad permissions
    - Hard to audit and maintain
+   - A dynamic namespace configuration cannot be resolved during manifest generation and therefore falls back to
+     cluster-wide RBAC
 
 3. **Incorrect Resource Definitions**:
    - Wrong API groups

--- a/docs/docs/operator/rbac.mdx
+++ b/docs/docs/operator/rbac.mdx
@@ -39,6 +39,10 @@ configuration or assigned through an external configuration method cannot be res
 CLI prints a warning and retains cluster-wide RBAC for compatibility. String literals, `const string` values, direct
 property assignment, and `WithNamespace` are supported.
 
+Statically resolved namespaces must be valid Kubernetes DNS-1123 labels: at most 63 lowercase alphanumeric characters
+or `-`, starting and ending with an alphanumeric character. Invalid values produce a warning and retain cluster-wide
+RBAC instead of generating invalid namespaced manifests.
+
 The initial namespaced generation support deploys the operator into the watched namespace. If the CLI `--namespace`
 option is supplied, it must match `OperatorSettings.Namespace`. Cluster-scoped entities and non-resource URL rules
 cannot be granted by a namespaced `Role` and cause generation to fail. For string-based `GenericRbacAttribute` rules,

--- a/docs/docs/operator/troubleshooting.mdx
+++ b/docs/docs/operator/troubleshooting.mdx
@@ -9,6 +9,22 @@ sidebar_position: 13
 This page collects the most common problems when running a KubeOps operator, their causes, and
 where to find the relevant configuration.
 
+## Generated RBAC remains cluster-wide
+
+**Symptom:** `OperatorSettings.Namespace` is configured, but manifest generation warns that the watch scope cannot be
+determined and emits a `ClusterRole` and `ClusterRoleBinding`.
+
+The CLI analyzes source code without executing application startup. Use a string literal or `const string` directly
+inside the `AddKubernetesOperator` lambda when namespaced RBAC should be generated:
+
+```csharp
+builder.Services.AddKubernetesOperator(settings =>
+    settings.Namespace = "tenant-a");
+```
+
+Values read from runtime configuration and configuration delegates passed as method groups cannot be determined
+statically. They intentionally retain cluster-wide RBAC to avoid generating insufficient permissions.
+
 ## Reconciliation does not fire
 
 **Symptom:** You change a resource, but `ReconcileAsync` is never called.

--- a/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
+++ b/src/KubeOps.Cli/Commands/Generator/OperatorGenerator.cs
@@ -9,10 +9,12 @@ using k8s;
 using k8s.Models;
 
 using KubeOps.Abstractions.Kustomize;
+using KubeOps.Abstractions.Rbac;
 using KubeOps.Cli.Extensions;
 using KubeOps.Cli.Generators;
 using KubeOps.Cli.Output;
 using KubeOps.Cli.Transpilation;
+using KubeOps.Transpiler;
 
 using Spectre.Console;
 
@@ -62,8 +64,6 @@ internal static class OperatorGenerator
         var dockerImage = parseResult.GetValue(Options.AccessibleDockerImage)!;
         var dockerImageTag = parseResult.GetValue(Options.AccessibleDockerTag)!;
         var operatorNamespace = parseResult.GetValue(Options.OperatorNamespace);
-        var effectiveNamespace = operatorNamespace ?? $"{name}-system";
-
         var result = new ResultOutput(console, format);
         console.WriteLine("Generate operator resources.");
 
@@ -80,12 +80,38 @@ internal static class OperatorGenerator
             _ => throw new NotSupportedException("Only *.csproj, *.sln, and *.slnx files are supported."),
         };
 
+        var watchScope = parser.GetOperatorWatchScope();
+        foreach (var diagnostic in watchScope.Diagnostics ?? [])
+        {
+            console.MarkupLineInterpolated($"[yellow]Warning:[/] {diagnostic}");
+        }
+
+        var effectiveNamespace = watchScope.Kind switch
+        {
+            OperatorWatchScopeKind.Namespaced when operatorNamespace is null => watchScope.Namespace!,
+            OperatorWatchScopeKind.Namespaced when operatorNamespace != watchScope.Namespace =>
+                throw new InvalidOperationException(
+                    $"The deployment namespace '{operatorNamespace}' differs from the statically configured " +
+                    $"operator watch namespace '{watchScope.Namespace}'. Separate deployment and watch namespaces " +
+                    "are not supported by generated manifests."),
+            _ => operatorNamespace ?? $"{name}-system",
+        };
+
+        if (watchScope.Kind == OperatorWatchScopeKind.Namespaced
+            && parser.GetRbacAttributes().Any(attribute =>
+                attribute.AttributeType == parser.GetContextType<GenericRbacAttribute>()))
+        {
+            console.MarkupLine(
+                "[yellow]Warning:[/] Generic RBAC rules must reference namespaced resources when the operator " +
+                "watch namespace is configured.");
+        }
+
         var mutators = parser.GetMutatedEntities().ToList();
         var validators = parser.GetValidatedEntities().ToList();
         var hasWebhooks = mutators.Count > 0 || validators.Count > 0 || parser.GetConvertedEntities().Any();
 
         console.MarkupLine("[green]Generate RBAC rules.[/]");
-        new RbacGenerator(parser, format, effectiveNamespace).Generate(result);
+        new RbacGenerator(parser, format, effectiveNamespace, watchScope).Generate(result);
 
         console.MarkupLine("[green]Generate Dockerfile.[/]");
         new DockerfileGenerator(hasWebhooks).Generate(result);
@@ -121,7 +147,7 @@ internal static class OperatorGenerator
             new CrdGenerator(parser, [], format).Generate(result);
         }
 
-        if (operatorNamespace is null)
+        if (operatorNamespace is null && watchScope.Kind != OperatorWatchScopeKind.Namespaced)
         {
             result.Add(
                 $"namespace.{format.GetFileExtension()}",

--- a/src/KubeOps.Cli/Generators/RbacGenerator.cs
+++ b/src/KubeOps.Cli/Generators/RbacGenerator.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using k8s;
 using k8s.Models;
 
+using KubeOps.Abstractions.Entities;
 using KubeOps.Abstractions.Rbac;
 using KubeOps.Cli.Output;
 using KubeOps.Cli.Transpilation;
@@ -17,7 +18,8 @@ namespace KubeOps.Cli.Generators;
 internal sealed class RbacGenerator(
     MetadataLoadContext parser,
     OutputFormat outputFormat,
-    string subjectNamespace) : IConfigGenerator
+    string subjectNamespace,
+    OperatorWatchScope watchScope) : IConfigGenerator
 {
     public void Generate(ResultOutput output)
     {
@@ -25,14 +27,67 @@ internal sealed class RbacGenerator(
             .GetRbacAttributes()
             .Concat(parser.GetContextType<DefaultRbacAttributes>().GetCustomAttributesData<EntityRbacAttribute>())
             .ToList();
+        var rules = parser.Transpile(attributes)
+            .OrderBy(r => r.ApiGroups?.FirstOrDefault() ?? string.Empty, StringComparer.Ordinal)
+            .ThenBy(r => r.Resources?.FirstOrDefault() ?? r.NonResourceURLs?.FirstOrDefault() ?? string.Empty, StringComparer.Ordinal)
+            .ToList();
 
-        var role = new V1ClusterRole
+        if (watchScope.Kind == OperatorWatchScopeKind.Namespaced)
         {
-            Rules = parser.Transpile(attributes)
-                .OrderBy(r => r.ApiGroups?.FirstOrDefault() ?? string.Empty, StringComparer.Ordinal)
-                .ThenBy(r => r.Resources?.FirstOrDefault() ?? r.NonResourceURLs?.FirstOrDefault() ?? string.Empty, StringComparer.Ordinal)
-                .ToList(),
-        }.Initialize();
+            ValidateNamespacedRules(attributes, rules);
+            GenerateNamespaced(output, rules);
+            return;
+        }
+
+        GenerateClusterWide(output, rules);
+    }
+
+    internal static V1Role CreateNamespacedRole(IList<V1PolicyRule> rules, string @namespace)
+    {
+        var role = new V1Role { Rules = rules }.Initialize();
+        role.Metadata.Name = "operator-role";
+        role.Metadata.NamespaceProperty = @namespace;
+        return role;
+    }
+
+    internal static V1RoleBinding CreateNamespacedRoleBinding(string @namespace)
+    {
+        var roleBinding = new V1RoleBinding
+        {
+            RoleRef = new()
+            {
+                ApiGroup = V1Role.KubeGroup,
+                Kind = V1Role.KubeKind,
+                Name = "operator-role",
+            },
+            Subjects = new List<Rbacv1Subject>
+            {
+                new()
+                {
+                    Kind = V1ServiceAccount.KubeKind,
+                    Name = "default",
+                    NamespaceProperty = @namespace,
+                },
+            },
+        }
+        .Initialize();
+        roleBinding.Metadata.Name = "operator-role-binding";
+        roleBinding.Metadata.NamespaceProperty = @namespace;
+        return roleBinding;
+    }
+
+    private void GenerateNamespaced(ResultOutput output, IList<V1PolicyRule> rules)
+    {
+        var role = CreateNamespacedRole(rules, subjectNamespace);
+        output.Add($"operator-role.{outputFormat.GetFileExtension()}", role);
+
+        var roleBinding = CreateNamespacedRoleBinding(subjectNamespace);
+        output.Add($"operator-role-binding.{outputFormat.GetFileExtension()}", roleBinding);
+    }
+
+    private void GenerateClusterWide(ResultOutput output, IList<V1PolicyRule> rules)
+    {
+        var role = new V1ClusterRole { Rules = rules }.Initialize();
         role.Metadata.Name = "operator-role";
         output.Add($"operator-role.{outputFormat.GetFileExtension()}", role);
 
@@ -57,6 +112,33 @@ internal sealed class RbacGenerator(
         .Initialize();
         roleBinding.Metadata.Name = "operator-role-binding";
         output.Add($"operator-role-binding.{outputFormat.GetFileExtension()}", roleBinding);
+    }
+
+    private void ValidateNamespacedRules(
+        IEnumerable<CustomAttributeData> attributes,
+        IEnumerable<V1PolicyRule> rules)
+    {
+        var entityRbacAttribute = parser.GetContextType<EntityRbacAttribute>();
+        var clusterScopedEntities = attributes
+            .Where(attribute => attribute.AttributeType == entityRbacAttribute)
+            .SelectMany(attribute => attribute.GetCustomAttributeCtorArrayArg<Type>(0))
+            .Where(type => parser.ToEntityMetadata(type).Scope == nameof(EntityScope.Cluster))
+            .Select(type => type.FullName ?? type.Name)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+        if (clusterScopedEntities.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Namespaced operator RBAC cannot grant access to cluster-scoped entities: " +
+                string.Join(", ", clusterScopedEntities));
+        }
+
+        if (rules.Any(rule => rule.NonResourceURLs is { Count: > 0 }))
+        {
+            throw new InvalidOperationException(
+                "Namespaced operator RBAC cannot grant access to non-resource URLs.");
+        }
     }
 
     [EntityRbac(typeof(Corev1Event), Verbs = RbacVerb.Get | RbacVerb.List | RbacVerb.Create | RbacVerb.Update)]

--- a/src/KubeOps.Cli/Transpilation/AssemblyLoader.cs
+++ b/src/KubeOps.Cli/Transpilation/AssemblyLoader.cs
@@ -37,6 +37,9 @@ internal static partial class AssemblyLoader
     private static readonly ConditionalWeakTable<MetadataLoadContext, IInheritedAttributeResolver>
         InheritedAttributeResolvers = new();
 
+    private static readonly ConditionalWeakTable<MetadataLoadContext, OperatorWatchScope>
+        OperatorWatchScopes = new();
+
     static AssemblyLoader()
     {
         MSBuildLocator.RegisterDefaults();
@@ -54,6 +57,11 @@ internal static partial class AssemblyLoader
         => InheritedAttributeResolvers.TryGetValue(context, out var resolver)
             ? resolver
             : ReflectionInheritedAttributeResolver.Default;
+
+    public static OperatorWatchScope GetOperatorWatchScope(this MetadataLoadContext context) =>
+        OperatorWatchScopes.TryGetValue(context, out var scope)
+            ? scope
+            : OperatorWatchScope.ClusterWide;
 
     public static Task<MetadataLoadContext> ForProject(
         IAnsiConsole console,
@@ -93,6 +101,8 @@ internal static partial class AssemblyLoader
 
             InheritedAttributeResolvers.AddOrUpdate(
                 mlc, new RoslynInheritedAttributeResolver(new[] { compilation }));
+            OperatorWatchScopes.AddOrUpdate(
+                mlc, OperatorWatchScopeDiscovery.Discover(new[] { compilation }));
 
             return mlc;
         });
@@ -178,6 +188,9 @@ internal static partial class AssemblyLoader
             InheritedAttributeResolvers.AddOrUpdate(
                 mlc,
                 new RoslynInheritedAttributeResolver(assemblies.Select(a => a.Compilation).ToList()));
+            OperatorWatchScopes.AddOrUpdate(
+                mlc,
+                OperatorWatchScopeDiscovery.Discover(assemblies.Select(a => a.Compilation)));
 
             return mlc;
         });

--- a/src/KubeOps.Cli/Transpilation/OperatorWatchScope.cs
+++ b/src/KubeOps.Cli/Transpilation/OperatorWatchScope.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace KubeOps.Cli.Transpilation;
+
+internal sealed record OperatorWatchScope(
+    OperatorWatchScopeKind Kind,
+    string? Namespace = null,
+    IReadOnlyList<OperatorWatchScopeDiagnostic>? Diagnostics = null)
+{
+    public static OperatorWatchScope ClusterWide { get; } = new(OperatorWatchScopeKind.ClusterWide);
+
+    public static OperatorWatchScope Namespaced(string @namespace) =>
+        new(OperatorWatchScopeKind.Namespaced, @namespace);
+
+    public static OperatorWatchScope Unknown(params OperatorWatchScopeDiagnostic[] diagnostics) =>
+        new(OperatorWatchScopeKind.Unknown, Diagnostics: diagnostics);
+}

--- a/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiagnostic.cs
+++ b/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiagnostic.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace KubeOps.Cli.Transpilation;
+
+internal sealed record OperatorWatchScopeDiagnostic(
+    string Message,
+    string? FilePath = null,
+    int? Line = null,
+    int? Character = null)
+{
+    public override string ToString() => (FilePath, Line, Character) switch
+    {
+        ({ Length: > 0 } path, { } line, { } character) => $"{path}({line},{character}): {Message}",
+        _ => Message,
+    };
+}

--- a/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiscovery.cs
+++ b/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiscovery.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Operations;
 
@@ -229,10 +230,12 @@ internal static class OperatorWatchScopeDiscovery
         private static bool IsSettingsExtension(IMethodSymbol method, string methodName) =>
             method.Name == methodName && IsKnownSettingsExtension(method);
 
-        private static bool IsConditional(SyntaxNode syntax) => syntax.Ancestors().Any(ancestor => ancestor is
-            IfStatementSyntax or ElseClauseSyntax or SwitchStatementSyntax or SwitchExpressionSyntax
-            or ConditionalExpressionSyntax or ForStatementSyntax or ForEachStatementSyntax
-            or WhileStatementSyntax or DoStatementSyntax or TryStatementSyntax);
+        private static bool IsConditional(SyntaxNode syntax) => syntax.Ancestors().Any(ancestor =>
+            (ancestor is IfStatementSyntax or ElseClauseSyntax or SwitchStatementSyntax or SwitchExpressionSyntax
+                or ConditionalExpressionSyntax or ConditionalAccessExpressionSyntax or ForStatementSyntax
+                or ForEachStatementSyntax or WhileStatementSyntax or DoStatementSyntax or TryStatementSyntax)
+            || (ancestor.Kind() is SyntaxKind.LogicalAndExpression or SyntaxKind.LogicalOrExpression
+                or SyntaxKind.CoalesceExpression));
 
         private static bool IsSafeSettingsReference(IParameterReferenceOperation operation)
         {

--- a/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiscovery.cs
+++ b/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiscovery.cs
@@ -152,6 +152,26 @@ internal static class OperatorWatchScopeDiscovery
 
         public SyntaxNode? UnknownSyntax { get; private set; }
 
+        public override void VisitAnonymousFunction(IAnonymousFunctionOperation operation)
+        {
+            if (ReferencesSettingsBuilder(operation))
+            {
+                SetUnknown(
+                    operation.Syntax,
+                    "The operator settings builder is captured by a nested lambda and cannot be evaluated statically.");
+            }
+        }
+
+        public override void VisitLocalFunction(ILocalFunctionOperation operation)
+        {
+            if (ReferencesSettingsBuilder(operation))
+            {
+                SetUnknown(
+                    operation.Syntax,
+                    "The operator settings builder is captured by a local function and cannot be evaluated statically.");
+            }
+        }
+
         public override void VisitSimpleAssignment(ISimpleAssignmentOperation operation)
         {
             if (operation.Target is IPropertyReferenceOperation property
@@ -239,6 +259,18 @@ internal static class OperatorWatchScopeDiscovery
                    && IsKnownSettingsExtension(instanceInvocation.TargetMethod);
         }
 
+        private static bool IsValidKubernetesNamespace(string value)
+        {
+            const int maxLength = 63;
+            return value.Length <= maxLength
+                   && IsLowercaseLetterOrDigit(value[0])
+                   && IsLowercaseLetterOrDigit(value[^1])
+                   && value.All(character => IsLowercaseLetterOrDigit(character) || character == '-');
+        }
+
+        private static bool IsLowercaseLetterOrDigit(char value) =>
+            (value >= 'a' && value <= 'z') || (value >= '0' && value <= '9');
+
         private void AddValue(IOperation operation, SyntaxNode syntax)
         {
             if (IsConditional(syntax))
@@ -260,12 +292,26 @@ internal static class OperatorWatchScopeDiscovery
                 return;
             }
 
+            if (value.Value is string @namespace && !IsValidKubernetesNamespace(@namespace))
+            {
+                SetUnknown(
+                    syntax,
+                    "The watch namespace must be a valid DNS-1123 label containing at most 63 lowercase " +
+                    "alphanumeric characters or '-', and must start and end with an alphanumeric character.");
+                return;
+            }
+
             _values.Add((string?)value.Value);
         }
 
         private bool UsesSettingsBuilderDirectly(IInvocationOperation operation) =>
             IsSettingsBuilder(operation.Instance)
             || operation.Arguments.Any(argument => IsSettingsBuilder(argument.Value));
+
+        private bool ReferencesSettingsBuilder(IOperation operation) =>
+            (operation is IParameterReferenceOperation parameterReference
+             && SymbolEqualityComparer.Default.Equals(parameterReference.Parameter, settingsParameter))
+            || operation.ChildOperations.Any(ReferencesSettingsBuilder);
 
         private bool IsSettingsBuilder(IOperation? operation)
         {

--- a/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiscovery.cs
+++ b/src/KubeOps.Cli/Transpilation/OperatorWatchScopeDiscovery.cs
@@ -1,0 +1,294 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace KubeOps.Cli.Transpilation;
+
+internal static class OperatorWatchScopeDiscovery
+{
+    private const string AddOperatorMethodName = "AddKubernetesOperator";
+    private const string OperatorExtensionsTypeName = "KubeOps.Operator.ServiceCollectionExtensions";
+    private const string SettingsExtensionsTypeName =
+        "KubeOps.Abstractions.Builder.OperatorSettingsBuilderExtensions";
+
+    public static OperatorWatchScope Discover(IEnumerable<Compilation> compilations)
+    {
+        var registrations = compilations.SelectMany(DiscoverRegistrations).ToList();
+        if (registrations.Count == 0)
+        {
+            return OperatorWatchScope.ClusterWide;
+        }
+
+        var diagnostics = registrations
+            .Where(registration => registration.Kind == OperatorWatchScopeKind.Unknown)
+            .SelectMany(registration => registration.Diagnostics ?? [])
+            .ToList();
+        if (diagnostics.Count > 0)
+        {
+            return OperatorWatchScope.Unknown(diagnostics.ToArray());
+        }
+
+        var distinctScopes = registrations
+            .Select(registration => (registration.Kind, registration.Namespace))
+            .Distinct()
+            .ToList();
+        if (distinctScopes.Count == 1)
+        {
+            var scope = distinctScopes[0];
+            return scope.Kind == OperatorWatchScopeKind.Namespaced
+                ? OperatorWatchScope.Namespaced(scope.Namespace!)
+                : OperatorWatchScope.ClusterWide;
+        }
+
+        return OperatorWatchScope.Unknown(new OperatorWatchScopeDiagnostic(
+            "Multiple AddKubernetesOperator registrations configure different watch namespaces."));
+    }
+
+    private static IEnumerable<OperatorWatchScope> DiscoverRegistrations(Compilation compilation)
+    {
+        foreach (var syntaxTree in compilation.SyntaxTrees)
+        {
+            var semanticModel = compilation.GetSemanticModel(syntaxTree);
+            var root = syntaxTree.GetRoot();
+            foreach (var invocationSyntax in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+            {
+                if (semanticModel.GetOperation(invocationSyntax) is not IInvocationOperation invocation
+                    || !IsAddOperatorInvocation(invocation.TargetMethod))
+                {
+                    continue;
+                }
+
+                yield return DiscoverRegistration(invocation, invocationSyntax);
+            }
+        }
+    }
+
+    private static OperatorWatchScope DiscoverRegistration(
+        IInvocationOperation invocation,
+        InvocationExpressionSyntax invocationSyntax)
+    {
+        var configureArgument = invocation.Arguments.FirstOrDefault(argument =>
+            argument.Parameter?.Name == "configure");
+        if (configureArgument is null || configureArgument.Value.ConstantValue is { HasValue: true, Value: null })
+        {
+            return OperatorWatchScope.ClusterWide;
+        }
+
+        var configureOperation = Unwrap(configureArgument.Value);
+        if (configureOperation is not IAnonymousFunctionOperation configure
+            || configure.Symbol.Parameters is not [{ } settingsParameter])
+        {
+            return Unknown(
+                invocationSyntax,
+                "The AddKubernetesOperator configuration delegate is not an inline lambda and cannot be evaluated statically.");
+        }
+
+        var walker = new NamespaceConfigurationWalker(settingsParameter);
+        walker.Visit(configure.Body);
+        if (walker.UnknownReason is not null)
+        {
+            return Unknown(walker.UnknownSyntax ?? invocationSyntax, walker.UnknownReason);
+        }
+
+        if (walker.Values.Count == 0)
+        {
+            return OperatorWatchScope.ClusterWide;
+        }
+
+        var distinctValues = walker.Values.Distinct(StringComparer.Ordinal).ToList();
+        if (distinctValues.Count != 1)
+        {
+            return Unknown(
+                invocationSyntax,
+                "The AddKubernetesOperator configuration assigns different watch namespaces.");
+        }
+
+        return distinctValues[0] is { } @namespace
+            ? OperatorWatchScope.Namespaced(@namespace)
+            : OperatorWatchScope.ClusterWide;
+    }
+
+    private static bool IsAddOperatorInvocation(IMethodSymbol method)
+    {
+        var definition = method.ReducedFrom ?? method;
+        return definition.Name == AddOperatorMethodName
+               && definition.ContainingType.ToDisplayString() == OperatorExtensionsTypeName;
+    }
+
+    private static IOperation Unwrap(IOperation operation)
+    {
+        while (operation is IConversionOperation conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation is IDelegateCreationOperation delegateCreation
+            ? delegateCreation.Target
+            : operation;
+    }
+
+    private static OperatorWatchScope Unknown(SyntaxNode syntax, string message)
+    {
+        var lineSpan = syntax.GetLocation().GetLineSpan();
+        var position = lineSpan.StartLinePosition;
+        return OperatorWatchScope.Unknown(new OperatorWatchScopeDiagnostic(
+            message,
+            lineSpan.Path,
+            position.Line + 1,
+            position.Character + 1));
+    }
+
+    private sealed class NamespaceConfigurationWalker(IParameterSymbol settingsParameter) : OperationWalker
+    {
+        private readonly List<string?> _values = [];
+
+        public IReadOnlyList<string?> Values => _values;
+
+        public string? UnknownReason { get; private set; }
+
+        public SyntaxNode? UnknownSyntax { get; private set; }
+
+        public override void VisitSimpleAssignment(ISimpleAssignmentOperation operation)
+        {
+            if (operation.Target is IPropertyReferenceOperation property
+                && property.Property.Name == "Namespace"
+                && IsSettingsBuilder(property.Instance))
+            {
+                AddValue(operation.Value, operation.Syntax);
+            }
+
+            base.VisitSimpleAssignment(operation);
+        }
+
+        public override void VisitInvocation(IInvocationOperation operation)
+        {
+            if (IsSettingsExtension(operation.TargetMethod, "WithNamespace")
+                && IsSettingsBuilder(operation.Instance ?? operation.Arguments.FirstOrDefault()?.Value))
+            {
+                var namespaceArgument = operation.Arguments.FirstOrDefault(argument =>
+                    argument.Parameter?.Name == "ns");
+                if (namespaceArgument is null)
+                {
+                    SetUnknown(operation.Syntax, "The WithNamespace argument could not be resolved.");
+                }
+                else
+                {
+                    AddValue(namespaceArgument.Value, operation.Syntax);
+                }
+            }
+            else if (UsesSettingsBuilderDirectly(operation) && !IsKnownSettingsExtension(operation.TargetMethod))
+            {
+                SetUnknown(
+                    operation.Syntax,
+                    "The operator settings builder is passed to a method that cannot be evaluated statically.");
+            }
+
+            base.VisitInvocation(operation);
+        }
+
+        public override void VisitParameterReference(IParameterReferenceOperation operation)
+        {
+            if (SymbolEqualityComparer.Default.Equals(operation.Parameter, settingsParameter)
+                && !IsSafeSettingsReference(operation))
+            {
+                SetUnknown(
+                    operation.Syntax,
+                    "The operator settings builder is used in a way that cannot be evaluated statically.");
+            }
+
+            base.VisitParameterReference(operation);
+        }
+
+        private static bool IsKnownSettingsExtension(IMethodSymbol method) =>
+            (method.ReducedFrom ?? method).ContainingType.ToDisplayString() == SettingsExtensionsTypeName;
+
+        private static bool IsSettingsExtension(IMethodSymbol method, string methodName) =>
+            method.Name == methodName && IsKnownSettingsExtension(method);
+
+        private static bool IsConditional(SyntaxNode syntax) => syntax.Ancestors().Any(ancestor => ancestor is
+            IfStatementSyntax or ElseClauseSyntax or SwitchStatementSyntax or SwitchExpressionSyntax
+            or ConditionalExpressionSyntax or ForStatementSyntax or ForEachStatementSyntax
+            or WhileStatementSyntax or DoStatementSyntax or TryStatementSyntax);
+
+        private static bool IsSafeSettingsReference(IParameterReferenceOperation operation)
+        {
+            IOperation current = operation;
+            while (current.Parent is IConversionOperation conversion)
+            {
+                current = conversion;
+            }
+
+            if (current.Parent is IPropertyReferenceOperation property && property.Instance == current)
+            {
+                return true;
+            }
+
+            if (current.Parent is IArgumentOperation argument
+                && argument.Parent is IInvocationOperation argumentInvocation
+                && IsKnownSettingsExtension(argumentInvocation.TargetMethod))
+            {
+                return true;
+            }
+
+            return current.Parent is IInvocationOperation instanceInvocation
+                   && instanceInvocation.Instance == current
+                   && IsKnownSettingsExtension(instanceInvocation.TargetMethod);
+        }
+
+        private void AddValue(IOperation operation, SyntaxNode syntax)
+        {
+            if (IsConditional(syntax))
+            {
+                SetUnknown(syntax, "The watch namespace is assigned conditionally and cannot be evaluated statically.");
+                return;
+            }
+
+            var value = Unwrap(operation).ConstantValue;
+            if (!value.HasValue || value.Value is not null and not string)
+            {
+                SetUnknown(syntax, "The watch namespace is not a compile-time constant.");
+                return;
+            }
+
+            if (value.Value is string { Length: 0 })
+            {
+                SetUnknown(syntax, "The watch namespace must not be empty.");
+                return;
+            }
+
+            _values.Add((string?)value.Value);
+        }
+
+        private bool UsesSettingsBuilderDirectly(IInvocationOperation operation) =>
+            IsSettingsBuilder(operation.Instance)
+            || operation.Arguments.Any(argument => IsSettingsBuilder(argument.Value));
+
+        private bool IsSettingsBuilder(IOperation? operation)
+        {
+            if (operation is null)
+            {
+                return false;
+            }
+
+            operation = Unwrap(operation);
+            return operation switch
+            {
+                IParameterReferenceOperation parameterReference =>
+                    SymbolEqualityComparer.Default.Equals(parameterReference.Parameter, settingsParameter),
+                IInvocationOperation invocation when IsKnownSettingsExtension(invocation.TargetMethod) =>
+                    IsSettingsBuilder(invocation.Instance ?? invocation.Arguments.FirstOrDefault()?.Value),
+                _ => false,
+            };
+        }
+
+        private void SetUnknown(SyntaxNode syntax, string reason)
+        {
+            UnknownReason ??= reason;
+            UnknownSyntax ??= syntax;
+        }
+    }
+}

--- a/src/KubeOps.Cli/Transpilation/OperatorWatchScopeKind.cs
+++ b/src/KubeOps.Cli/Transpilation/OperatorWatchScopeKind.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace KubeOps.Cli.Transpilation;
+
+internal enum OperatorWatchScopeKind
+{
+    /// <summary>
+    /// The operator watches resources across the cluster.
+    /// </summary>
+    ClusterWide,
+
+    /// <summary>
+    /// The operator watches resources in one namespace.
+    /// </summary>
+    Namespaced,
+
+    /// <summary>
+    /// The operator watch scope cannot be determined statically.
+    /// </summary>
+    Unknown,
+}

--- a/test/KubeOps.Cli.Test/Generators/RbacGenerator.Test.cs
+++ b/test/KubeOps.Cli.Test/Generators/RbacGenerator.Test.cs
@@ -2,16 +2,27 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System.Reflection;
+
 using FluentAssertions;
 
+using k8s;
 using k8s.Models;
 
+using KubeOps.Abstractions.Rbac;
 using KubeOps.Cli.Generators;
+using KubeOps.Cli.Output;
+using KubeOps.Cli.Transpilation;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using Spectre.Console.Testing;
 
 namespace KubeOps.Cli.Test.Generators;
 
 [Trait("Area", "Rbac")]
-public class RbacGeneratorTest
+public sealed class RbacGeneratorTest
 {
     [Fact]
     public void Should_Create_Namespaced_Role()
@@ -51,5 +62,136 @@ public class RbacGeneratorTest
             Name = "default",
             NamespaceProperty = "tenant-a",
         });
+    }
+
+    [Fact]
+    public void Should_Generate_Namespaced_Rbac_Resources()
+    {
+        using var parser = CreateParser(
+            """
+            [GenericRbac(Groups = new[] { "" }, Resources = new[] { "pods" }, Verbs = RbacVerb.Get)]
+            """);
+        var output = CreateOutput();
+
+        new RbacGenerator(
+                parser,
+                OutputFormat.Yaml,
+                "tenant-a",
+                OperatorWatchScope.Namespaced("tenant-a"))
+            .Generate(output);
+
+        output.Files.Should().BeEquivalentTo("operator-role.yaml", "operator-role-binding.yaml");
+        var role = output["operator-role.yaml"].Should().BeOfType<V1Role>().Subject;
+        role.Metadata.NamespaceProperty.Should().Be("tenant-a");
+        role.Rules.Should().Contain(rule => rule.Resources!.Contains("pods"));
+        KubernetesYaml.Deserialize<V1Role>(KubernetesYaml.Serialize(role))
+            .Should().BeEquivalentTo(role);
+        output["operator-role-binding.yaml"].Should().BeOfType<V1RoleBinding>();
+    }
+
+    [Fact]
+    public void Should_Generate_Cluster_Wide_Rbac_Resources()
+    {
+        using var parser = CreateParser(
+            """
+            [GenericRbac(Groups = new[] { "" }, Resources = new[] { "pods" }, Verbs = RbacVerb.Get)]
+            """);
+        var output = CreateOutput();
+
+        new RbacGenerator(parser, OutputFormat.Yaml, "operator-system", OperatorWatchScope.ClusterWide)
+            .Generate(output);
+
+        output["operator-role.yaml"].Should().BeOfType<V1ClusterRole>();
+        output["operator-role-binding.yaml"].Should().BeOfType<V1ClusterRoleBinding>();
+    }
+
+    [Fact]
+    public void Should_Reject_Cluster_Scoped_Entities_For_Namespaced_Rbac()
+    {
+        using var parser = CreateParser(
+            """
+            [KubernetesEntity(Group = "example.com", ApiVersion = "v1", Kind = "ClusterEntity")]
+            [EntityScope(EntityScope.Cluster)]
+            internal sealed class ClusterEntity : CustomKubernetesEntity;
+
+            [EntityRbac(typeof(ClusterEntity), Verbs = RbacVerb.Get)]
+            internal sealed class ClusterController;
+            """);
+        var output = CreateOutput();
+        var generator = new RbacGenerator(
+            parser,
+            OutputFormat.Yaml,
+            "tenant-a",
+            OperatorWatchScope.Namespaced("tenant-a"));
+
+        var action = () => generator.Generate(output);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*cluster-scoped entities*ClusterEntity*");
+    }
+
+    [Fact]
+    public void Should_Reject_Non_Resource_Urls_For_Namespaced_Rbac()
+    {
+        using var parser = CreateParser(
+            """
+            [GenericRbac(Urls = new[] { "/healthz" }, Verbs = RbacVerb.Get)]
+            """);
+        var output = CreateOutput();
+        var generator = new RbacGenerator(
+            parser,
+            OutputFormat.Yaml,
+            "tenant-a",
+            OperatorWatchScope.Namespaced("tenant-a"));
+
+        var action = () => generator.Generate(output);
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*non-resource URLs*");
+    }
+
+    private static ResultOutput CreateOutput() => new(new TestConsole(), OutputFormat.Yaml);
+
+    private static MetadataLoadContext CreateParser(string attribute)
+    {
+        var source = $$"""
+            using k8s.Models;
+            using KubeOps.Abstractions.Entities;
+            using KubeOps.Abstractions.Entities.Attributes;
+            using KubeOps.Abstractions.Rbac;
+
+            {{attribute}}
+            internal sealed class RbacTestType;
+            """;
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "RbacTestType.cs");
+        var referencePaths = GetReferencePaths().ToList();
+        var compilation = CSharpCompilation.Create(
+            $"RbacGeneratorTestAssembly-{Guid.NewGuid():N}",
+            [syntaxTree],
+            referencePaths.Select(path => MetadataReference.CreateFromFile(path)),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var assemblyStream = new MemoryStream();
+        var result = compilation.Emit(assemblyStream);
+        result.Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+
+        var parser = new MetadataLoadContext(new PathAssemblyResolver(referencePaths));
+        parser.LoadFromByteArray(assemblyStream.ToArray());
+        return parser;
+    }
+
+    private static IEnumerable<string> GetReferencePaths()
+    {
+        var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
+            ?? throw new InvalidOperationException("Trusted platform assemblies are unavailable.");
+
+        return trustedPlatformAssemblies.Split(Path.PathSeparator)
+            .Concat(new[]
+            {
+                typeof(V1Namespace).Assembly.Location,
+                typeof(EntityRbacAttribute).Assembly.Location,
+                typeof(RbacGenerator).Assembly.Location,
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/test/KubeOps.Cli.Test/Generators/RbacGenerator.Test.cs
+++ b/test/KubeOps.Cli.Test/Generators/RbacGenerator.Test.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using FluentAssertions;
+
+using k8s.Models;
+
+using KubeOps.Cli.Generators;
+
+namespace KubeOps.Cli.Test.Generators;
+
+[Trait("Area", "Rbac")]
+public class RbacGeneratorTest
+{
+    [Fact]
+    public void Should_Create_Namespaced_Role()
+    {
+        var rules = new List<V1PolicyRule>
+        {
+            new()
+            {
+                ApiGroups = ["example.com"],
+                Resources = ["examples"],
+                Verbs = ["get", "list", "watch"],
+            },
+        };
+
+        var role = RbacGenerator.CreateNamespacedRole(rules, "tenant-a");
+
+        role.Kind.Should().Be(V1Role.KubeKind);
+        role.Metadata.Name.Should().Be("operator-role");
+        role.Metadata.NamespaceProperty.Should().Be("tenant-a");
+        role.Rules.Should().BeSameAs(rules);
+    }
+
+    [Fact]
+    public void Should_Create_Namespaced_Role_Binding()
+    {
+        var binding = RbacGenerator.CreateNamespacedRoleBinding("tenant-a");
+
+        binding.Kind.Should().Be(V1RoleBinding.KubeKind);
+        binding.Metadata.Name.Should().Be("operator-role-binding");
+        binding.Metadata.NamespaceProperty.Should().Be("tenant-a");
+        binding.RoleRef.ApiGroup.Should().Be(V1Role.KubeGroup);
+        binding.RoleRef.Kind.Should().Be(V1Role.KubeKind);
+        binding.RoleRef.Name.Should().Be("operator-role");
+        binding.Subjects.Should().ContainSingle().Which.Should().BeEquivalentTo(new Rbacv1Subject
+        {
+            Kind = V1ServiceAccount.KubeKind,
+            Name = "default",
+            NamespaceProperty = "tenant-a",
+        });
+    }
+}

--- a/test/KubeOps.Cli.Test/Transpilation/OperatorWatchScopeDiscovery.Test.cs
+++ b/test/KubeOps.Cli.Test/Transpilation/OperatorWatchScopeDiscovery.Test.cs
@@ -2,13 +2,10 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
-
 using FluentAssertions;
 
 using KubeOps.Abstractions.Builder;
 using KubeOps.Cli.Transpilation;
-using KubeOps.Operator;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -17,7 +14,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace KubeOps.Cli.Test.Transpilation;
 
 [Trait("Area", "Rbac")]
-public class OperatorWatchScopeDiscoveryTest
+public sealed class OperatorWatchScopeDiscoveryTest
 {
     [Fact]
     public void Should_Detect_Cluster_Wide_Registration_Without_Configuration()
@@ -52,6 +49,40 @@ public class OperatorWatchScopeDiscoveryTest
 
         scope.Kind.Should().Be(OperatorWatchScopeKind.Namespaced);
         scope.Namespace.Should().Be("tenant-a");
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("Tenant-a")]
+    [InlineData("-tenant-a")]
+    [InlineData("tenant-a-")]
+    [InlineData("tenant.a")]
+    public void Should_Report_Invalid_Constant_Namespace_As_Unknown(string invalidNamespace)
+    {
+        var scope = Discover(
+            $$"""
+            const string WatchNamespace = "{{invalidNamespace}}";
+            services.AddKubernetesOperator(settings => settings.Namespace = WatchNamespace);
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("DNS-1123 label");
+    }
+
+    [Fact]
+    public void Should_Report_Too_Long_Constant_Namespace_As_Unknown()
+    {
+        var invalidNamespace = new string('a', 64);
+        var scope = Discover(
+            $$"""
+            const string WatchNamespace = "{{invalidNamespace}}";
+            services.AddKubernetesOperator(settings => settings.Namespace = WatchNamespace);
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("DNS-1123 label");
     }
 
     [Fact]
@@ -133,6 +164,54 @@ public class OperatorWatchScopeDiscoveryTest
             .Which.Message.Should().Contain("different watch namespaces");
     }
 
+    [Fact]
+    public void Should_Report_Settings_Captured_By_Nested_Lambda_As_Unknown()
+    {
+        var scope = Discover(
+            """
+            services.AddKubernetesOperator(settings =>
+            {
+                System.Action configureLater = () => settings.Namespace = "tenant-a";
+            });
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("nested lambda");
+    }
+
+    [Fact]
+    public void Should_Report_Settings_Captured_By_Local_Function_As_Unknown()
+    {
+        var scope = Discover(
+            """
+            services.AddKubernetesOperator(settings =>
+            {
+                void ConfigureLater() => settings.Namespace = "tenant-a";
+            });
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("local function");
+    }
+
+    [Fact]
+    public void Should_Ignore_Unrelated_Nested_Lambda()
+    {
+        var scope = Discover(
+            """
+            services.AddKubernetesOperator(settings =>
+            {
+                System.Action unrelated = () => { };
+                settings.Namespace = "tenant-a";
+            });
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Namespaced);
+        scope.Namespace.Should().Be("tenant-a");
+    }
+
     private static OperatorWatchScope Discover(string statements)
     {
         var source = $$"""
@@ -164,7 +243,7 @@ public class OperatorWatchScopeDiscoveryTest
         var paths = trustedPlatformAssemblies.Split(Path.PathSeparator).Concat(new[]
         {
             typeof(OperatorSettingsBuilder).Assembly.Location,
-            typeof(KubeOps.Operator.ServiceCollectionExtensions).Assembly.Location,
+            typeof(Operator.ServiceCollectionExtensions).Assembly.Location,
             typeof(IServiceCollection).Assembly.Location,
             typeof(ServiceCollection).Assembly.Location,
         });

--- a/test/KubeOps.Cli.Test/Transpilation/OperatorWatchScopeDiscovery.Test.cs
+++ b/test/KubeOps.Cli.Test/Transpilation/OperatorWatchScopeDiscovery.Test.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+using FluentAssertions;
+
+using KubeOps.Abstractions.Builder;
+using KubeOps.Cli.Transpilation;
+using KubeOps.Operator;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KubeOps.Cli.Test.Transpilation;
+
+[Trait("Area", "Rbac")]
+public class OperatorWatchScopeDiscoveryTest
+{
+    [Fact]
+    public void Should_Detect_Cluster_Wide_Registration_Without_Configuration()
+    {
+        var scope = Discover("services.AddKubernetesOperator();");
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.ClusterWide);
+        scope.Namespace.Should().BeNull();
+    }
+
+    [Fact]
+    public void Should_Detect_Namespace_From_Assignment()
+    {
+        var scope = Discover("services.AddKubernetesOperator(settings => settings.Namespace = \"tenant-a\");");
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Namespaced);
+        scope.Namespace.Should().Be("tenant-a");
+    }
+
+    [Fact]
+    public void Should_Detect_Namespace_From_Constant()
+    {
+        var scope = Discover(
+            """
+            const string WatchNamespace = "tenant-a";
+            services.AddKubernetesOperator(settings =>
+            {
+                settings.Namespace = WatchNamespace;
+                settings.LeaderElectionType = LeaderElectionType.Single;
+            });
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Namespaced);
+        scope.Namespace.Should().Be("tenant-a");
+    }
+
+    [Fact]
+    public void Should_Detect_Namespace_From_Fluent_Configuration()
+    {
+        var scope = Discover(
+            "services.AddKubernetesOperator(settings => settings.WithName(\"test\").WithNamespace(\"tenant-a\"));");
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Namespaced);
+        scope.Namespace.Should().Be("tenant-a");
+    }
+
+    [Fact]
+    public void Should_Detect_Cluster_Wide_Registration_When_Other_Settings_Are_Configured()
+    {
+        var scope = Discover(
+            "services.AddKubernetesOperator(settings => settings.LeaderElectionType = LeaderElectionType.Single);");
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.ClusterWide);
+    }
+
+    [Fact]
+    public void Should_Report_Dynamic_Namespace_As_Unknown()
+    {
+        var scope = Discover(
+            """
+            var configuredNamespace = System.Environment.GetEnvironmentVariable("OPERATOR_NAMESPACE");
+            services.AddKubernetesOperator(settings => settings.Namespace = configuredNamespace);
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("compile-time constant");
+    }
+
+    [Fact]
+    public void Should_Report_Method_Group_As_Unknown()
+    {
+        var scope = Discover(
+            """
+            services.AddKubernetesOperator(Configure);
+
+            static void Configure(OperatorSettingsBuilder settings) => settings.Namespace = "tenant-a";
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("inline lambda");
+    }
+
+    [Fact]
+    public void Should_Report_Aliased_Settings_Builder_As_Unknown()
+    {
+        var scope = Discover(
+            """
+            services.AddKubernetesOperator(settings =>
+            {
+                var alias = settings;
+                alias.Namespace = "tenant-a";
+            });
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("cannot be evaluated statically");
+    }
+
+    [Fact]
+    public void Should_Report_Conflicting_Registrations_As_Unknown()
+    {
+        var scope = Discover(
+            """
+            services.AddKubernetesOperator(settings => settings.Namespace = "tenant-a");
+            services.AddKubernetesOperator(settings => settings.Namespace = "tenant-b");
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("different watch namespaces");
+    }
+
+    private static OperatorWatchScope Discover(string statements)
+    {
+        var source = $$"""
+            using KubeOps.Abstractions.Builder;
+            using KubeOps.Operator;
+            using Microsoft.Extensions.DependencyInjection;
+
+            IServiceCollection services = new ServiceCollection();
+            {{statements}}
+            """;
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "Program.cs");
+        var compilation = CSharpCompilation.Create(
+            "OperatorWatchScopeTest",
+            [syntaxTree],
+            GetReferences(),
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication));
+
+        compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Should().BeEmpty();
+
+        return OperatorWatchScopeDiscovery.Discover([compilation]);
+    }
+
+    private static IEnumerable<MetadataReference> GetReferences()
+    {
+        var trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")
+            ?? throw new InvalidOperationException("Trusted platform assemblies are unavailable.");
+        var paths = trustedPlatformAssemblies.Split(Path.PathSeparator).Concat(new[]
+        {
+            typeof(OperatorSettingsBuilder).Assembly.Location,
+            typeof(KubeOps.Operator.ServiceCollectionExtensions).Assembly.Location,
+            typeof(IServiceCollection).Assembly.Location,
+            typeof(ServiceCollection).Assembly.Location,
+        });
+
+        return paths.Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => MetadataReference.CreateFromFile(path));
+    }
+}

--- a/test/KubeOps.Cli.Test/Transpilation/OperatorWatchScopeDiscovery.Test.cs
+++ b/test/KubeOps.Cli.Test/Transpilation/OperatorWatchScopeDiscovery.Test.cs
@@ -118,6 +118,26 @@ public sealed class OperatorWatchScopeDiscoveryTest
             .Which.Message.Should().Contain("compile-time constant");
     }
 
+    [Theory]
+    [InlineData("string? value = null; _ = value?.Contains(settings.Namespace = \"tenant-a\");")]
+    [InlineData("_ = false && (settings.Namespace = \"tenant-a\") is not null;")]
+    [InlineData("_ = true || (settings.Namespace = \"tenant-a\") is not null;")]
+    [InlineData("string? value = \"selected\"; _ = value ?? (settings.Namespace = \"tenant-a\");")]
+    public void Should_Report_Conditionally_Evaluated_Namespace_As_Unknown(string statement)
+    {
+        var scope = Discover(
+            $$"""
+            services.AddKubernetesOperator(settings =>
+            {
+                {{statement}}
+            });
+            """);
+
+        scope.Kind.Should().Be(OperatorWatchScopeKind.Unknown);
+        scope.Diagnostics.Should().ContainSingle()
+            .Which.Message.Should().Contain("conditionally");
+    }
+
     [Fact]
     public void Should_Report_Method_Group_As_Unknown()
     {


### PR DESCRIPTION
- automatically generates `Role` and `RoleBinding` for operators with a static `OperatorSettings.Namespace` configuration.
- falls back to cluster-wide RBAC when namespace values cannot be resolved statically.
- includes validation for unsupported cluster-scoped entities and non-resource URLs in namespaced RBAC.

fixes #1213 