### PR TITLE
fix: Stack overflow when transpiling type with self-referential property

### DIFF
--- a/src/KubeOps.Transpiler/Crds.cs
+++ b/src/KubeOps.Transpiler/Crds.cs
@@ -220,6 +220,7 @@ public static class Crds
         inheritedAttributeResolver ??= ReflectionInheritedAttributeResolver.Default;
 
         var props = type.GetProperties()
+            .Where(p => p.GetCustomAttributeData<IgnoreAttribute>() == null)
             .Select(p => (Prop: p, Path: string.Empty, Ancestors: (IReadOnlySet<Type>)new HashSet<Type> { type }))
             .ToList();
         while (props.Count > 0)
@@ -233,6 +234,7 @@ public static class Crds
             {
                 IReadOnlySet<Type> childAncestors = new HashSet<Type>(ancestors) { prop.PropertyType };
                 props.AddRange(prop.PropertyType.GetProperties()
+                    .Where(p => p.GetCustomAttributeData<IgnoreAttribute>() == null)
                     .Select(p => (Prop: p, Path: $"{path}.{prop.GetPropertyName(context)}", Ancestors: childAncestors)));
             }
 

--- a/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
+++ b/test/KubeOps.Transpiler.Test/Crds.Mlc.Test.cs
@@ -851,6 +851,19 @@ public sealed partial class CrdsMlcTest(MlcProvider provider) : TranspilerTestBa
         specProperties.Should().Contain(p => p.Key == "otherName");
     }
 
+    [Trait("Area", "PropertyAttributes")]
+    [Fact]
+    public void Should_Not_Recurse_Into_Ignored_Self_Referential_Property()
+    {
+        // A self-referential property marked with [Ignore] must not be traversed during
+        // printer-column discovery, otherwise CRD generation recurses until it overflows the stack.
+        var crd = _mlc.Transpile(typeof(RecursiveIgnoreAttrEntity));
+
+        var specProperties = crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties["spec"];
+        specProperties.Properties.Should().ContainKey("data");
+        specProperties.Properties.Should().NotContainKey("children");
+    }
+
     [Trait("Area", "General")]
     [Fact]
     public void Should_Use_Kubernetes_Json_Property_Naming_For_Acronym_Prefixes()
@@ -1740,6 +1753,18 @@ public sealed partial class CrdsMlcTest(MlcProvider provider) : TranspilerTestBa
         {
             [Ignore]
             public string Property { get; set; } = null!;
+        }
+    }
+
+    [KubernetesEntity(Group = "testing.dev", ApiVersion = "v1", Kind = "TestEntity")]
+    public class RecursiveIgnoreAttrEntity : CustomKubernetesEntity<RecursiveIgnoreAttrEntity.EntitySpec>
+    {
+        public class EntitySpec
+        {
+            public string Data { get; set; } = null!;
+
+            [Ignore]
+            public List<EntitySpec>? Children { get; set; }
         }
     }
 


### PR DESCRIPTION
The transpiler had a bug where using a self-referential property caused stack overflow (infinite recursion) even if the property was explicitly ignored. This PR simply adds the missing filtering to `MapPrinterColumns`.